### PR TITLE
redistribute funds across destinations

### DIFF
--- a/contracts/dca/src/contract.rs
+++ b/contracts/dca/src/contract.rs
@@ -98,6 +98,7 @@ pub fn execute(
         } => create_pair(deps, env, info, address, base_denom, quote_denom),
         ExecuteMsg::DeletePair { address } => delete_pair(deps, env, info, address),
         ExecuteMsg::CreateVault {
+            destinations,
             pair_address,
             position_type,
             slippage_tolerance,
@@ -109,6 +110,7 @@ pub fn execute(
             deps,
             env,
             info,
+            destinations,
             pair_address,
             position_type,
             slippage_tolerance,

--- a/contracts/dca/src/msg.rs
+++ b/contracts/dca/src/msg.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use base::pair::Pair;
 use base::triggers::trigger::{TimeInterval, Trigger};
-use base::vaults::vault::PositionType;
+use base::vaults::vault::{Destination, PositionType};
 
 use crate::vault::Vault;
 
@@ -35,6 +35,7 @@ pub enum ExecuteMsg {
         address: String,
     },
     CreateVault {
+        destinations: Vec<Destination>,
         pair_address: String,
         position_type: PositionType,
         slippage_tolerance: Option<Decimal256>,

--- a/contracts/dca/src/tests/cancel_vault_tests.rs
+++ b/contracts/dca/src/tests/cancel_vault_tests.rs
@@ -19,6 +19,7 @@ fn when_vault_has_unfulfilled_fin_limit_order_trigger_should_succeed() {
         .with_funds_for(&user_address, user_balance, DENOM_UKUJI)
         .with_vault_with_unfilled_fin_limit_price_trigger(
             &user_address,
+            vec![],
             Coin::new(user_balance.into(), DENOM_UKUJI),
             swap_amount,
             "fin",
@@ -199,6 +200,7 @@ fn when_vault_has_time_trigger_should_succeed() {
         .with_funds_for(&user_address, TEN, DENOM_UKUJI)
         .with_vault_with_time_trigger(
             &user_address,
+            vec![],
             Coin::new(vault_deposit.into(), DENOM_UKUJI),
             swap_amount,
             "fin",

--- a/contracts/dca/src/tests/contract_tests.rs
+++ b/contracts/dca/src/tests/contract_tests.rs
@@ -372,6 +372,7 @@ fn cancel_vault_with_valid_inputs_should_succeed() {
     .unwrap();
 
     let create_vault_execute_message = ExecuteMsg::CreateVault {
+        destinations: vec![],
         pair_address: String::from(VALID_ADDRESS_TWO),
         position_type: PositionType::Enter,
         slippage_tolerance: None,
@@ -446,6 +447,7 @@ fn get_active_vault_by_address_and_id_should_succeed() {
     .unwrap();
 
     let create_vault_execute_message = ExecuteMsg::CreateVault {
+        destinations: vec![],
         pair_address: String::from(VALID_ADDRESS_TWO),
         position_type: PositionType::Enter,
         slippage_tolerance: None,
@@ -516,6 +518,7 @@ fn get_all_active_vaults_by_address_should_succeed() {
     .unwrap();
 
     let create_vault_execute_message_one = ExecuteMsg::CreateVault {
+        destinations: vec![],
         pair_address: String::from(VALID_ADDRESS_TWO),
         position_type: PositionType::Enter,
         slippage_tolerance: None,
@@ -540,6 +543,7 @@ fn get_all_active_vaults_by_address_should_succeed() {
     .unwrap();
 
     let create_vault_execute_message_two = ExecuteMsg::CreateVault {
+        destinations: vec![],
         pair_address: String::from(VALID_ADDRESS_TWO),
         position_type: PositionType::Enter,
         slippage_tolerance: None,
@@ -610,6 +614,7 @@ fn get_all_events_by_vault_id_for_new_vault_should_succeed() {
     .unwrap();
 
     let create_vault_execute_message = ExecuteMsg::CreateVault {
+        destinations: vec![],
         pair_address: String::from(VALID_ADDRESS_TWO),
         position_type: PositionType::Enter,
         slippage_tolerance: None,

--- a/contracts/dca/src/tests/create_vault_tests.rs
+++ b/contracts/dca/src/tests/create_vault_tests.rs
@@ -11,8 +11,8 @@ use base::events::event::{EventBuilder, EventData};
 use base::helpers::message_helpers::get_flat_map_for_event_type;
 use base::pair::Pair;
 use base::triggers::trigger::TimeInterval;
-use base::vaults::vault::{PositionType, VaultStatus};
-use cosmwasm_std::{Addr, Coin, Decimal256, Uint128, Uint64};
+use base::vaults::vault::{Destination, PositionType, VaultStatus};
+use cosmwasm_std::{Addr, Coin, Decimal, Decimal256, Uint128, Uint64};
 use cw_multi_test::Executor;
 use std::str::FromStr;
 
@@ -45,6 +45,7 @@ fn with_fin_limit_order_trigger_should_update_address_balances() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -108,6 +109,7 @@ fn with_fin_limit_order_trigger_should_create_vault() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -136,6 +138,10 @@ fn with_fin_limit_order_trigger_should_create_vault() {
         Vault {
             id: Uint128::new(1),
             owner: user_address.clone(),
+            destinations: vec![Destination {
+                address: user_address.clone(),
+                allocation: Decimal::percent(100),
+            }],
             created_at: mock.app.block_info().time,
             status: VaultStatus::Active,
             balance: Coin::new(vault_deposit.into(), DENOM_UKUJI.to_string()),
@@ -162,6 +168,7 @@ fn with_price_trigger_with_existing_vault_should_create_vault() {
         .with_funds_for(&user_address, user_balance, DENOM_UKUJI)
         .with_vault_with_filled_fin_limit_price_trigger(
             &user_address,
+            vec![],
             Coin::new(vault_deposit.into(), DENOM_UKUJI),
             swap_amount,
             "fin",
@@ -173,6 +180,7 @@ fn with_price_trigger_with_existing_vault_should_create_vault() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -201,6 +209,10 @@ fn with_price_trigger_with_existing_vault_should_create_vault() {
         Vault {
             id: Uint128::new(2),
             owner: user_address.clone(),
+            destinations: vec![Destination {
+                address: user_address.clone(),
+                allocation: Decimal::percent(100),
+            }],
             created_at: mock.app.block_info().time,
             status: VaultStatus::Active,
             position_type: PositionType::Enter,
@@ -233,6 +245,7 @@ fn with_price_trigger_should_publish_vault_created_event() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -264,6 +277,7 @@ fn with_fin_limit_order_trigger_twice_for_user_should_succeed() {
         .with_funds_for(&user_address, user_balance, DENOM_UKUJI)
         .with_vault_with_filled_fin_limit_price_trigger(
             &user_address,
+            vec![],
             Coin::new(vault_deposit.into(), DENOM_UKUJI),
             swap_amount,
             "fin",
@@ -295,6 +309,7 @@ fn with_fin_limit_order_trigger_twice_for_user_should_succeed() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -382,6 +397,7 @@ fn with_time_trigger_should_update_address_balances() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -430,6 +446,7 @@ fn with_time_trigger_should_create_vault() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -455,6 +472,10 @@ fn with_time_trigger_should_create_vault() {
         Vault {
             id: Uint128::new(1),
             owner: user_address.clone(),
+            destinations: vec![Destination {
+                address: user_address.clone(),
+                allocation: Decimal::percent(100),
+            }],
             created_at: mock.app.block_info().time,
             status: VaultStatus::Active,
             position_type: PositionType::Enter,
@@ -481,6 +502,7 @@ fn with_time_trigger_with_existing_vault_should_create_vault() {
         .with_funds_for(&user_address, user_balance, DENOM_UKUJI)
         .with_vault_with_time_trigger(
             &user_address,
+            vec![],
             Coin::new(vault_deposit.into(), DENOM_UKUJI),
             swap_amount,
             "time",
@@ -494,6 +516,7 @@ fn with_time_trigger_with_existing_vault_should_create_vault() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -521,6 +544,10 @@ fn with_time_trigger_with_existing_vault_should_create_vault() {
         vault_response.vault,
         Vault {
             id: Uint128::new(2),
+            destinations: vec![Destination {
+                address: user_address.clone(),
+                allocation: Decimal::percent(100),
+            }],
             owner: user_address.clone(),
             created_at: mock.app.block_info().time,
             status: VaultStatus::Active,
@@ -555,6 +582,7 @@ fn with_time_trigger_should_publish_vault_created_event() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -593,6 +621,7 @@ fn with_time_trigger_with_no_target_time_should_succeed() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -642,6 +671,75 @@ fn with_time_trigger_with_no_target_time_should_succeed() {
 }
 
 #[test]
+fn with_mulitple_destinations_should_succeed() {
+    let user_address = Addr::unchecked(USER);
+    let user_balance = TEN;
+    let vault_deposit = TEN;
+    let swap_amount = ONE;
+    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
+        &user_address,
+        user_balance,
+        DENOM_UKUJI,
+    );
+
+    let mut destinations = vec![];
+
+    for _ in 0..5 {
+        destinations.push(Destination {
+            address: Addr::unchecked(USER),
+            allocation: Decimal::percent(20),
+        });
+    }
+
+    mock.app
+        .execute_contract(
+            Addr::unchecked(USER),
+            mock.dca_contract_address.clone(),
+            &ExecuteMsg::CreateVault {
+                destinations: destinations.clone(),
+                pair_address: mock.fin_contract_address.to_string(),
+                position_type: PositionType::Enter,
+                slippage_tolerance: None,
+                swap_amount,
+                time_interval: TimeInterval::Hourly,
+                target_start_time_utc_seconds: None,
+                target_price: None,
+            },
+            &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
+        )
+        .unwrap();
+
+    let vault_id = Uint128::new(1);
+
+    let vault_response: VaultResponse = mock
+        .app
+        .wrap()
+        .query_wasm_smart(&mock.dca_contract_address, &QueryMsg::GetVault { vault_id })
+        .unwrap();
+
+    assert_eq!(
+        vault_response.vault,
+        Vault {
+            id: Uint128::new(1),
+            owner: user_address.clone(),
+            destinations,
+            created_at: mock.app.block_info().time,
+            status: VaultStatus::Active,
+            position_type: PositionType::Enter,
+            time_interval: TimeInterval::Hourly,
+            balance: Coin::new(vault_deposit.into(), DENOM_UKUJI.to_string()),
+            slippage_tolerance: None,
+            swap_amount,
+            pair: Pair {
+                address: mock.fin_contract_address.clone(),
+                base_denom: DENOM_UTEST.to_string(),
+                quote_denom: DENOM_UKUJI.to_string(),
+            },
+        }
+    );
+}
+
+#[test]
 fn with_time_trigger_with_target_time_in_the_past_should_fail() {
     let user_address = Addr::unchecked(USER);
     let user_balance = TEN;
@@ -659,6 +757,7 @@ fn with_time_trigger_with_target_time_in_the_past_should_fail() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -697,6 +796,7 @@ fn with_price_and_time_trigger_should_fail() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -734,6 +834,7 @@ fn with_no_assets_should_fail() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -768,6 +869,7 @@ fn with_multiple_assets_should_fail() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: mock.fin_contract_address.to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -807,6 +909,7 @@ fn with_non_existent_pair_address_should_fail() {
             Addr::unchecked(USER),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CreateVault {
+                destinations: vec![],
                 pair_address: "not-a-pair-address".to_string(),
                 position_type: PositionType::Enter,
                 slippage_tolerance: None,
@@ -822,5 +925,91 @@ fn with_non_existent_pair_address_should_fail() {
     assert_eq!(
         response.root_cause().to_string(),
         "base::pair::Pair not found"
+    );
+}
+
+#[test]
+fn with_destination_allocations_less_than_100_percent_should_fail() {
+    let user_address = Addr::unchecked(USER);
+    let user_balance = TEN;
+    let vault_deposit = TEN;
+    let swap_amount = ONE;
+    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
+        &user_address,
+        user_balance,
+        DENOM_UKUJI,
+    );
+
+    let response = mock
+        .app
+        .execute_contract(
+            Addr::unchecked(USER),
+            mock.dca_contract_address.clone(),
+            &ExecuteMsg::CreateVault {
+                destinations: vec![Destination {
+                    address: Addr::unchecked(USER),
+                    allocation: Decimal::percent(50),
+                }],
+                pair_address: mock.fin_contract_address.to_string(),
+                position_type: PositionType::Enter,
+                slippage_tolerance: None,
+                swap_amount,
+                time_interval: TimeInterval::Hourly,
+                target_start_time_utc_seconds: None,
+                target_price: None,
+            },
+            &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        response.root_cause().to_string(),
+        "Error: destination allocations must add up to 1"
+    );
+}
+
+#[test]
+fn with_more_than_10_destination_allocations_should_fail() {
+    let user_address = Addr::unchecked(USER);
+    let user_balance = TEN;
+    let vault_deposit = TEN;
+    let swap_amount = ONE;
+    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
+        &user_address,
+        user_balance,
+        DENOM_UKUJI,
+    );
+
+    let mut destinations = vec![];
+
+    for _ in 0..20 {
+        destinations.push(Destination {
+            address: Addr::unchecked(USER),
+            allocation: Decimal::percent(5),
+        });
+    }
+
+    let response = mock
+        .app
+        .execute_contract(
+            Addr::unchecked(USER),
+            mock.dca_contract_address.clone(),
+            &ExecuteMsg::CreateVault {
+                destinations,
+                pair_address: mock.fin_contract_address.to_string(),
+                position_type: PositionType::Enter,
+                slippage_tolerance: None,
+                swap_amount,
+                time_interval: TimeInterval::Hourly,
+                target_start_time_utc_seconds: None,
+                target_price: None,
+            },
+            &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        response.root_cause().to_string(),
+        "Error: no more than 10 destinations can be provided"
     );
 }

--- a/contracts/dca/src/tests/mocks.rs
+++ b/contracts/dca/src/tests/mocks.rs
@@ -4,7 +4,7 @@ use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, VaultResponse};
 use crate::vault::Vault;
 use base::helpers::message_helpers::get_flat_map_for_event_type;
 use base::triggers::trigger::TimeInterval;
-use base::vaults::vault::PositionType;
+use base::vaults::vault::{Destination, PositionType};
 use cosmwasm_schema::serde::Serialize;
 use cosmwasm_std::{
     to_binary, Addr, BankMsg, Binary, Coin, Decimal256, Empty, Env, Event, MessageInfo, Response,
@@ -180,6 +180,7 @@ impl MockApp {
     pub fn with_vault_with_unfilled_fin_limit_price_trigger(
         mut self,
         owner: &Addr,
+        destinations: Vec<Destination>,
         balance: Coin,
         swap_amount: Uint128,
         label: &str,
@@ -190,6 +191,7 @@ impl MockApp {
                 owner.clone(),
                 self.dca_contract_address.clone(),
                 &ExecuteMsg::CreateVault {
+                    destinations,
                     pair_address: self.fin_contract_address.to_string(),
                     position_type: PositionType::Enter,
                     slippage_tolerance: None,
@@ -216,6 +218,7 @@ impl MockApp {
     pub fn with_vault_with_filled_fin_limit_price_trigger(
         mut self,
         owner: &Addr,
+        destinations: Vec<Destination>,
         balance: Coin,
         swap_amount: Uint128,
         label: &str,
@@ -226,6 +229,7 @@ impl MockApp {
                 owner.clone(),
                 self.dca_contract_address.clone(),
                 &ExecuteMsg::CreateVault {
+                    destinations,
                     pair_address: self.fin_contract_address.to_string(),
                     position_type: PositionType::Enter,
                     slippage_tolerance: None,
@@ -280,6 +284,7 @@ impl MockApp {
                 owner.clone(),
                 self.dca_contract_address.clone(),
                 &ExecuteMsg::CreateVault {
+                    destinations: vec![],
                     pair_address: self.fin_contract_address.to_string(),
                     position_type: PositionType::Enter,
                     slippage_tolerance: None,
@@ -330,6 +335,7 @@ impl MockApp {
     pub fn with_vault_with_time_trigger(
         mut self,
         owner: &Addr,
+        destinations: Vec<Destination>,
         balance: Coin,
         swap_amount: Uint128,
         label: &str,
@@ -340,6 +346,7 @@ impl MockApp {
                 owner.clone(),
                 self.dca_contract_address.clone(),
                 &ExecuteMsg::CreateVault {
+                    destinations,
                     pair_address: self.fin_contract_address.to_string(),
                     position_type: PositionType::Enter,
                     slippage_tolerance: None,

--- a/contracts/dca/src/vault.rs
+++ b/contracts/dca/src/vault.rs
@@ -1,7 +1,7 @@
 use base::{
     pair::Pair,
     triggers::trigger::TimeInterval,
-    vaults::vault::{PositionType, VaultStatus},
+    vaults::vault::{Destination, PositionType, VaultStatus},
 };
 use cosmwasm_std::{Addr, Coin, Decimal256, Timestamp, Uint128};
 use schemars::JsonSchema;
@@ -12,6 +12,7 @@ pub struct Vault {
     pub id: Uint128,
     pub created_at: Timestamp,
     pub owner: Addr,
+    pub destinations: Vec<Destination>,
     pub status: VaultStatus,
     pub balance: Coin,
     pub pair: Pair,

--- a/packages/base/src/vaults/vault.rs
+++ b/packages/base/src/vaults/vault.rs
@@ -1,3 +1,4 @@
+use cosmwasm_std::{Addr, Decimal};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -9,7 +10,14 @@ pub enum PositionType {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum VaultStatus {
     Active,
     Inactive,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Destination {
+    pub address: Addr,
+    pub allocation: Decimal,
 }


### PR DESCRIPTION
Destinations have an address and an allocation - allocations must be a decimal < 1 and all add up to 1.

@aidan-calculated 