### PR TITLE
add generated swap struct to vault dtos

### DIFF
--- a/contracts/dca/src/handlers/after_fin_limit_order_retracted.rs
+++ b/contracts/dca/src/handlers/after_fin_limit_order_retracted.rs
@@ -44,8 +44,8 @@ pub fn after_fin_limit_order_retracted(
             // if the entire amount isnt retracted, order was partially filled need to send the partially filled assets to user
             if amount_retracted != limit_order_cache.original_offer_amount {
                 let retracted_balance = Coin {
-                    denom: vault.get_swap_denom().clone(),
-                    amount: vault.balance.amount - (vault.swap_amount - amount_retracted),
+                    denom: vault.get_swap().send_denom.clone(),
+                    amount: vault.balance.amount - (vault.get_swap().amount - amount_retracted),
                 };
 
                 // i dont think its possible for this to be zero
@@ -81,7 +81,7 @@ pub fn after_fin_limit_order_retracted(
                             Some(mut existing_vault) => {
                                 existing_vault.status = VaultStatus::Cancelled;
                                 existing_vault.balance =
-                                    Coin::new(0, existing_vault.get_swap_denom());
+                                    Coin::new(0, existing_vault.get_swap().send_denom);
                                 Ok(existing_vault)
                             }
                             None => Err(StdError::NotFound {

--- a/contracts/dca/src/handlers/after_fin_limit_order_withdrawn_for_cancel_vault.rs
+++ b/contracts/dca/src/handlers/after_fin_limit_order_withdrawn_for_cancel_vault.rs
@@ -21,7 +21,7 @@ pub fn after_fin_limit_order_withdrawn_for_cancel_vault(
 
             // send assets from partially filled order to owner
             let filled_amount = Coin {
-                denom: vault.get_receive_denom().clone(),
+                denom: vault.get_swap().receive_denom.clone(),
                 amount: limit_order_cache.filled,
             };
 
@@ -43,7 +43,8 @@ pub fn after_fin_limit_order_withdrawn_for_cancel_vault(
                     match existing_vault {
                         Some(mut existing_vault) => {
                             existing_vault.status = VaultStatus::Cancelled;
-                            existing_vault.balance = Coin::new(0, existing_vault.get_swap_denom());
+                            existing_vault.balance =
+                                Coin::new(0, existing_vault.get_swap().send_denom);
                             Ok(existing_vault)
                         }
                         None => Err(StdError::NotFound {

--- a/contracts/dca/src/handlers/after_fin_limit_order_withdrawn_for_execute_trigger.rs
+++ b/contracts/dca/src/handlers/after_fin_limit_order_withdrawn_for_execute_trigger.rs
@@ -72,7 +72,7 @@ pub fn after_fin_limit_order_withdrawn_for_execute_vault(
             )?;
 
             let coin_received = Coin {
-                denom: vault.get_receive_denom().clone(),
+                denom: vault.get_swap().receive_denom.clone(),
                 amount: limit_order_cache.filled,
             };
 
@@ -123,7 +123,7 @@ pub fn after_fin_limit_order_withdrawn_for_execute_vault(
                                 msg: to_binary(&StakingRouterExecuteMsg::ZDelegate {
                                     delegator_address: vault.owner.clone(),
                                     validator_address: destination.address.clone(),
-                                    denom: vault.get_receive_denom(),
+                                    denom: vault.get_swap().receive_denom,
                                     amount,
                                 })
                                 .unwrap(),
@@ -142,7 +142,7 @@ pub fn after_fin_limit_order_withdrawn_for_execute_vault(
                     env.block,
                     EventData::DCAVaultExecutionCompleted {
                         sent: Coin {
-                            denom: vault.get_swap_denom().clone(),
+                            denom: vault.get_swap().send_denom.clone(),
                             amount: limit_order_cache.original_offer_amount,
                         },
                         received: coin_received,

--- a/contracts/dca/src/handlers/after_fin_swap.rs
+++ b/contracts/dca/src/handlers/after_fin_swap.rs
@@ -40,11 +40,11 @@ pub fn after_fin_swap(deps: DepsMut, env: Env, reply: Reply) -> Result<Response,
             let (coin_sent, coin_received) = match vault.position_type {
                 PositionType::Enter => {
                     let sent = Coin {
-                        denom: vault.get_swap_denom(),
+                        denom: vault.get_swap().send_denom,
                         amount: Uint128::from(quote_amount),
                     };
                     let received = Coin {
-                        denom: vault.get_receive_denom(),
+                        denom: vault.get_swap().receive_denom,
                         amount: Uint128::from(base_amount),
                     };
 
@@ -52,11 +52,11 @@ pub fn after_fin_swap(deps: DepsMut, env: Env, reply: Reply) -> Result<Response,
                 }
                 PositionType::Exit => {
                     let sent = Coin {
-                        denom: vault.get_swap_denom(),
+                        denom: vault.get_swap().send_denom,
                         amount: Uint128::from(base_amount),
                     };
                     let received = Coin {
-                        denom: vault.get_receive_denom(),
+                        denom: vault.get_swap().receive_denom,
                         amount: Uint128::from(quote_amount),
                     };
 
@@ -111,7 +111,7 @@ pub fn after_fin_swap(deps: DepsMut, env: Env, reply: Reply) -> Result<Response,
                                 msg: to_binary(&StakingRouterExecuteMsg::ZDelegate {
                                     delegator_address: vault.owner.clone(),
                                     validator_address: destination.address.clone(),
-                                    denom: vault.get_receive_denom(),
+                                    denom: vault.get_swap().receive_denom,
                                     amount,
                                 })
                                 .unwrap(),

--- a/contracts/dca/src/handlers/cancel_vault.rs
+++ b/contracts/dca/src/handlers/cancel_vault.rs
@@ -66,7 +66,7 @@ fn cancel_time_trigger(deps: DepsMut, vault: Vault) -> Result<Response, Contract
             match existing_vault {
                 Some(mut existing_vault) => {
                     existing_vault.status = VaultStatus::Cancelled;
-                    existing_vault.balance = Coin::new(0, existing_vault.get_swap_denom());
+                    existing_vault.balance = Coin::new(0, existing_vault.get_swap().send_denom);
                     Ok(existing_vault)
                 }
                 None => Err(StdError::NotFound {

--- a/contracts/dca/src/handlers/create_vault.rs
+++ b/contracts/dca/src/handlers/create_vault.rs
@@ -79,17 +79,17 @@ pub fn create_vault(
     }
 
     let vault_builder = VaultBuilder {
+        created_at: env.block.time,
         owner,
         label,
         destinations,
-        created_at: env.block.time,
         status: VaultStatus::Scheduled,
+        balance: info.funds[0].clone(),
         pair,
         swap_amount,
         position_type,
         slippage_tolerance,
         price_threshold,
-        balance: info.funds[0].clone(),
         time_interval: time_interval.clone(),
         started_at: None,
     };

--- a/contracts/dca/src/handlers/get_vault.rs
+++ b/contracts/dca/src/handlers/get_vault.rs
@@ -7,11 +7,14 @@ pub fn get_vault(deps: Deps, address: Addr, vault_id: Uint128) -> StdResult<Vaul
 
     if vault.owner != address {
         return Err(StdError::NotFound {
-            kind: format!("vault for address: {} with id: {}", address, vault.id),
+            kind: format!("vault for address={} with id={}", address, vault.id),
         });
     }
 
     let trigger = get_trigger(deps.storage, vault.id).ok();
 
-    Ok(VaultResponse { vault, trigger })
+    Ok(VaultResponse {
+        vault: vault.into(),
+        trigger,
+    })
 }

--- a/contracts/dca/src/handlers/get_vaults_by_address.rs
+++ b/contracts/dca/src/handlers/get_vaults_by_address.rs
@@ -13,5 +13,7 @@ pub fn get_vaults_by_address(
 
     let vaults = fetch_vaults_by_address(deps.storage, address, start_after, limit)?;
 
-    Ok(VaultsResponse { vaults })
+    Ok(VaultsResponse {
+        vaults: vaults.into_iter().map(|v| v.into()).collect(),
+    })
 }

--- a/contracts/dca/src/msg.rs
+++ b/contracts/dca/src/msg.rs
@@ -1,11 +1,10 @@
+use crate::vault::VaultDTO;
 use base::events::event::Event;
 use base::pair::Pair;
 use base::triggers::trigger::{TimeInterval, Trigger};
 use base::vaults::vault::{Destination, PositionType};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal256, Uint128, Uint64};
-
-use crate::vault::Vault;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -112,13 +111,13 @@ pub struct TriggerIdsResponse {
 
 #[cw_serde]
 pub struct VaultResponse {
-    pub vault: Vault,
+    pub vault: VaultDTO,
     pub trigger: Option<Trigger>,
 }
 
 #[cw_serde]
 pub struct VaultsResponse {
-    pub vaults: Vec<Vault>,
+    pub vaults: Vec<VaultDTO>,
 }
 
 #[cw_serde]

--- a/contracts/dca/src/tests/create_vault_tests.rs
+++ b/contracts/dca/src/tests/create_vault_tests.rs
@@ -6,7 +6,7 @@ use crate::tests::helpers::{
 use crate::tests::mocks::{
     fin_contract_unfilled_limit_order, MockApp, DENOM_UKUJI, DENOM_UTEST, USER,
 };
-use crate::vault::Vault;
+use crate::vault::{Swap, VaultDTO};
 use base::events::event::{EventBuilder, EventData};
 use base::helpers::message_helpers::get_flat_map_for_event_type;
 use base::pair::Pair;
@@ -147,7 +147,7 @@ fn with_fin_limit_order_trigger_should_create_vault() {
 
     assert_eq!(
         vault_response.vault,
-        Vault {
+        VaultDTO {
             price_threshold: None,
             label: Some("label".to_string()),
             id: Uint128::new(1),
@@ -162,8 +162,14 @@ fn with_fin_limit_order_trigger_should_create_vault() {
             balance: Coin::new(vault_deposit.into(), DENOM_UKUJI.to_string()),
             position_type: PositionType::Enter,
             time_interval: TimeInterval::Hourly,
-            slippage_tolerance: None,
             swap_amount,
+            swap: Swap {
+                address: mock.fin_contract_address.clone(),
+                send_denom: DENOM_UKUJI.to_string(),
+                receive_denom: DENOM_UTEST.to_string(),
+                amount: swap_amount,
+            },
+            slippage_tolerance: None,
             pair: Pair {
                 address: mock.fin_contract_address.clone(),
                 base_denom: DENOM_UTEST.to_string(),
@@ -294,7 +300,7 @@ fn with_price_trigger_with_existing_vault_should_create_vault() {
 
     assert_eq!(
         vault_response.vault,
-        Vault {
+        VaultDTO {
             price_threshold: None,
             label: Some("label".to_string()),
             id: Uint128::new(2),
@@ -309,8 +315,14 @@ fn with_price_trigger_with_existing_vault_should_create_vault() {
             position_type: PositionType::Enter,
             time_interval: TimeInterval::Hourly,
             slippage_tolerance: None,
-            balance: Coin::new(vault_deposit.into(), DENOM_UKUJI),
             swap_amount,
+            swap: Swap {
+                address: mock.fin_contract_address.clone(),
+                send_denom: DENOM_UKUJI.to_string(),
+                receive_denom: DENOM_UTEST.to_string(),
+                amount: swap_amount,
+            },
+            balance: Coin::new(vault_deposit.into(), DENOM_UKUJI),
             pair: Pair {
                 address: mock.fin_contract_address.clone(),
                 base_denom: DENOM_UTEST.to_string(),
@@ -579,7 +591,7 @@ fn with_time_trigger_should_create_vault() {
 
     assert_eq!(
         vault_response.vault,
-        Vault {
+        VaultDTO {
             price_threshold: None,
             label: Some("label".to_string()),
             id: Uint128::new(1),
@@ -594,8 +606,14 @@ fn with_time_trigger_should_create_vault() {
             position_type: PositionType::Enter,
             time_interval: TimeInterval::Hourly,
             balance: Coin::new(vault_deposit.into(), DENOM_UKUJI.to_string()),
-            slippage_tolerance: None,
             swap_amount,
+            swap: Swap {
+                address: mock.fin_contract_address.clone(),
+                send_denom: DENOM_UKUJI.to_string(),
+                receive_denom: DENOM_UTEST.to_string(),
+                amount: swap_amount,
+            },
+            slippage_tolerance: None,
             pair: Pair {
                 address: mock.fin_contract_address.clone(),
                 base_denom: DENOM_UTEST.to_string(),
@@ -666,7 +684,7 @@ fn with_time_trigger_with_existing_vault_should_create_vault() {
 
     assert_eq!(
         vault_response.vault,
-        Vault {
+        VaultDTO {
             price_threshold: None,
             label: Some("label".to_string()),
             id: Uint128::new(2),
@@ -680,9 +698,15 @@ fn with_time_trigger_with_existing_vault_should_create_vault() {
             status: VaultStatus::Scheduled,
             position_type: PositionType::Enter,
             slippage_tolerance: None,
+            swap_amount,
+            swap: Swap {
+                address: mock.fin_contract_address.clone(),
+                send_denom: DENOM_UKUJI.to_string(),
+                receive_denom: DENOM_UTEST.to_string(),
+                amount: swap_amount,
+            },
             time_interval: TimeInterval::Hourly,
             balance: Coin::new(vault_deposit.into(), DENOM_UKUJI.to_string()),
-            swap_amount,
             pair: Pair {
                 address: mock.fin_contract_address.clone(),
                 base_denom: DENOM_UTEST.to_string(),
@@ -855,7 +879,7 @@ fn with_mulitple_destinations_should_succeed() {
 
     assert_eq!(
         vault_response.vault,
-        Vault {
+        VaultDTO {
             price_threshold: None,
             label: Some("label".to_string()),
             id: Uint128::new(1),
@@ -865,9 +889,15 @@ fn with_mulitple_destinations_should_succeed() {
             status: VaultStatus::Scheduled,
             position_type: PositionType::Enter,
             time_interval: TimeInterval::Hourly,
+            swap_amount,
+            swap: Swap {
+                address: mock.fin_contract_address.clone(),
+                send_denom: DENOM_UKUJI.to_string(),
+                receive_denom: DENOM_UTEST.to_string(),
+                amount: swap_amount,
+            },
             balance: Coin::new(vault_deposit.into(), DENOM_UKUJI.to_string()),
             slippage_tolerance: None,
-            swap_amount,
             pair: Pair {
                 address: mock.fin_contract_address.clone(),
                 base_denom: DENOM_UTEST.to_string(),

--- a/contracts/dca/src/tests/helpers.rs
+++ b/contracts/dca/src/tests/helpers.rs
@@ -1,7 +1,7 @@
 use super::mocks::MockApp;
 use crate::{
     msg::{EventsResponse, QueryMsg, VaultResponse},
-    vault::Vault,
+    vault::VaultDTO,
 };
 use base::events::event::Event;
 use cosmwasm_std::{Addr, Uint128};
@@ -20,7 +20,12 @@ pub fn assert_address_balances(mock: &MockApp, address_balances: &[(&Addr, &str,
         })
 }
 
-pub fn assert_vault_eq(mock: &MockApp, address: Addr, vault_id: Uint128, expected_vault: Vault) {
+pub fn assert_vault_data_eq(
+    mock: &MockApp,
+    address: Addr,
+    vault_id: Uint128,
+    expected_vault: VaultDTO,
+) {
     let vault_response: VaultResponse = mock
         .app
         .wrap()

--- a/contracts/dca/src/tests/mocks.rs
+++ b/contracts/dca/src/tests/mocks.rs
@@ -1,7 +1,7 @@
 use crate::constants::{ONE, ONE_THOUSAND};
 use crate::contract::reply;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, VaultResponse};
-use crate::vault::Vault;
+use crate::vault::VaultDTO;
 use base::helpers::message_helpers::get_flat_map_for_event_type;
 use base::triggers::trigger::TimeInterval;
 use base::vaults::vault::{Destination, PositionType};
@@ -395,7 +395,7 @@ impl MockApp {
         });
     }
 
-    pub fn get_vault_by_label(&self, label: &str, address: Addr) -> Vault {
+    pub fn get_vault_by_label(&self, label: &str, address: Addr) -> VaultDTO {
         let vault_id = self.vault_ids.get(label).unwrap();
         let vault_response: VaultResponse = self
             .app


### PR DESCRIPTION
**Motivation:** 

 Use `Swap` instead of `Pair` struct on vaults because `Pair` has no directionality and depends upon the vault `position_type` to determine which denom to send to FIN.

**Changes:**

* returning `VaultDTO` in queries to manage the disparity between vault schema and api schema
* generating vault dto `swap` struct using vault stored data

**What's next:**

* generate and store the `Swap` against the vault once the front end has switched away from using `swap_amount` and `pair` values on the vault itself.

**Additional thoughts:**

Do we want to take this further and have an `Action` enum that maybe even encapsulates the `PostExecutionAction` enum and adds values for `Swap`, `Rebalance` etc.?

#95 