### PR TITLE
store pair address and load pair in on reads

### DIFF
--- a/contracts/dca/src/state/vaults.rs
+++ b/contracts/dca/src/state/vaults.rs
@@ -138,12 +138,13 @@ pub fn get_vaults_by_address(
         )
         .take(limit.unwrap_or(30) as usize)
         .map(|result| {
-            let (_, data) = result.expect("a vault stored by id");
+            let (_, data) =
+                result.expect(format!("a vault with id after {:?}", start_after).as_str());
             vault_from(
                 &data,
                 PAIRS
                     .load(store, data.pair_address.clone())
-                    .expect("a pair for pair address"),
+                    .expect(format!("a pair for pair address {:?}", data.pair_address).as_str()),
             )
         })
         .collect::<Vec<Vault>>())


### PR DESCRIPTION
Changes include:
* Adding a `VaultData` struct for vault storage
* Leaving the vault store functions using `Vault`s, and do required transforms within the `state/vaults.rs` functions