### PR TITLE
remove position type from events

### DIFF
--- a/contracts/dca/src/handlers/execute_trigger.rs
+++ b/contracts/dca/src/handlers/execute_trigger.rs
@@ -57,7 +57,6 @@ pub fn execute_trigger(
             EventData::DCAVaultExecutionTriggered {
                 base_denom: vault.pair.base_denom.clone(),
                 quote_denom: vault.pair.quote_denom.clone(),
-                position_type: position_type.clone(),
                 asset_price: current_price.clone(),
             },
         ),

--- a/contracts/dca/src/tests/execute_trigger_tests.rs
+++ b/contracts/dca/src/tests/execute_trigger_tests.rs
@@ -13,7 +13,7 @@ use crate::tests::mocks::{
 };
 use base::events::event::{EventBuilder, EventData};
 use base::helpers::math_helpers::checked_mul;
-use base::vaults::vault::{Destination, PositionType, PostExecutionAction, VaultStatus};
+use base::vaults::vault::{Destination, PostExecutionAction, VaultStatus};
 use cosmwasm_std::{Addr, Coin, Decimal, Decimal256, Uint128};
 use cw_multi_test::Executor;
 
@@ -252,7 +252,6 @@ fn for_filled_fin_limit_order_trigger_should_publish_events() {
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    position_type: PositionType::Enter,
                     asset_price: Decimal256::from_str("1.0").unwrap(),
                 },
             )
@@ -833,7 +832,6 @@ fn for_ready_time_trigger_should_create_events() {
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    position_type: PositionType::Enter,
                     asset_price: Decimal256::from_str("1.0").unwrap(),
                 },
             )
@@ -1051,7 +1049,6 @@ fn for_ready_time_trigger_within_price_threshold_should_succeed() {
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    position_type: PositionType::Enter,
                     asset_price: Decimal256::from_str("1.0").unwrap(),
                 },
             )
@@ -1145,7 +1142,6 @@ fn for_ready_time_trigger_outside_of_price_threshold_should_skip_execution() {
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    position_type: PositionType::Enter,
                     asset_price: Decimal256::from_str("1.0").unwrap(),
                 },
             )
@@ -1717,7 +1713,6 @@ fn until_vault_is_empty_should_create_events() {
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    position_type: PositionType::Enter,
                     asset_price: Decimal256::from_str("1.0").unwrap(),
                 },
             )
@@ -1738,7 +1733,6 @@ fn until_vault_is_empty_should_create_events() {
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    position_type: PositionType::Enter,
                     asset_price: Decimal256::from_str("1.0").unwrap(),
                 },
             )

--- a/packages/base/src/events/event.rs
+++ b/packages/base/src/events/event.rs
@@ -1,7 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{BlockInfo, Coin, Decimal256, Timestamp, Uint128};
 
-use crate::vaults::vault::PositionType;
 use fin_helpers::codes::{ERROR_SWAP_INSUFFICIENT_FUNDS, ERROR_SWAP_SLIPPAGE};
 
 #[cw_serde]
@@ -33,7 +32,6 @@ pub enum EventData {
     DCAVaultExecutionTriggered {
         base_denom: String,
         quote_denom: String,
-        position_type: PositionType,
         asset_price: Decimal256,
     },
     DCAVaultExecutionCompleted {


### PR DESCRIPTION
Missed that one - @aidan-calculated, also wondering if we need the execution triggered event at all? Given we have execution completed and execution failed events, the triggered event is kind of redundant (aware that this is against what I said earlier to just create events that we don't know if we will need or not, but i do think we can get the same info from the completed/failed events)