### PR TITLE
parse fin swap error strings to get failure type

### DIFF
--- a/contracts/dca/src/handlers/cancel_vault.rs
+++ b/contracts/dca/src/handlers/cancel_vault.rs
@@ -37,7 +37,7 @@ pub fn cancel_vault(
     match vault
         .trigger
         .clone()
-        .expect(format!("trigger for vault id {:?}", vault.id).as_str())
+        .expect(format!("trigger for vault id {}", vault.id).as_str())
     {
         TriggerConfiguration::Time { .. } => cancel_time_trigger(deps, vault),
         TriggerConfiguration::FINLimitOrder { order_idx, .. } => {

--- a/contracts/dca/src/handlers/execute_trigger.rs
+++ b/contracts/dca/src/handlers/execute_trigger.rs
@@ -73,7 +73,7 @@ pub fn execute_trigger(
     match vault
         .trigger
         .clone()
-        .expect(format!("trigger for vault id {:?}", vault.id).as_str())
+        .expect(format!("trigger for vault id {}", vault.id).as_str())
     {
         TriggerConfiguration::Time { target_time } => {
             assert_target_time_is_in_past(env.block.time, target_time)?;

--- a/contracts/dca/src/state/vaults.rs
+++ b/contracts/dca/src/state/vaults.rs
@@ -148,7 +148,7 @@ pub fn get_vaults_by_address(
                     .load(store, data.pair_address.clone())
                     .expect(format!("a pair for pair address {:?}", data.pair_address).as_str()),
                 get_trigger(store, data.id.into())
-                    .expect(format!("a trigger for vault id {:?}", data.id).as_str())
+                    .expect(format!("a trigger for vault id {}", data.id).as_str())
                     .map(|t| t.configuration),
             )
         })

--- a/contracts/dca/src/tests/mocks.rs
+++ b/contracts/dca/src/tests/mocks.rs
@@ -12,7 +12,6 @@ use cosmwasm_std::{
     Response, StdError, StdResult, Uint128, Uint256, Uint64,
 };
 use cw_multi_test::{App, AppBuilder, Contract, ContractWrapper, Executor};
-use fin_helpers::codes::ERROR_SWAP_SLIPPAGE_EXCEEDED;
 use kujira::denom::Denom;
 use kujira::fin::{
     BookResponse, ExecuteMsg as FINExecuteMsg, InstantiateMsg as FINInstantiateMsg, OrderResponse,
@@ -691,10 +690,7 @@ pub fn fin_contract_fail_slippage_tolerance() -> Box<dyn Contract<Empty>> {
         |_, _, _, msg: FINExecuteMsg| -> StdResult<Response> {
             match msg {
                 FINExecuteMsg::Swap { .. } => Err(StdError::GenericErr {
-                    msg: format!(
-                        "Error: code: ({:?}), msg: Max spread exceeded 0.992445703493862134",
-                        ERROR_SWAP_SLIPPAGE_EXCEEDED
-                    ),
+                    msg: "Max spread exceeded 0.992445703493862134".to_string(),
                 }),
                 _ => Ok(Response::default()),
             }

--- a/packages/base/src/events/event.rs
+++ b/packages/base/src/events/event.rs
@@ -1,26 +1,11 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{BlockInfo, Coin, Decimal256, Timestamp, Uint128};
 
-use fin_helpers::codes::{ERROR_SWAP_INSUFFICIENT_FUNDS, ERROR_SWAP_SLIPPAGE_EXCEEDED};
-
 #[cw_serde]
 pub enum ExecutionSkippedReason {
     SlippageToleranceExceeded,
-    InsufficientFunds,
     PriceThresholdExceeded { price: Decimal256 },
     UnknownFailure,
-}
-
-impl ExecutionSkippedReason {
-    pub fn from_fin_swap_error(e: String) -> Self {
-        if e.contains(ERROR_SWAP_SLIPPAGE_EXCEEDED) {
-            ExecutionSkippedReason::SlippageToleranceExceeded
-        } else if e.contains(ERROR_SWAP_INSUFFICIENT_FUNDS) {
-            ExecutionSkippedReason::InsufficientFunds
-        } else {
-            ExecutionSkippedReason::UnknownFailure
-        }
-    }
 }
 
 #[cw_serde]

--- a/packages/fin-helpers/src/codes.rs
+++ b/packages/fin-helpers/src/codes.rs
@@ -1,2 +1,1 @@
-pub const ERROR_SWAP_SLIPPAGE_EXCEEDED: &str = "5";
-pub const ERROR_SWAP_INSUFFICIENT_FUNDS: &str = "10";
+pub const ERROR_SWAP_SLIPPAGE_EXCEEDED: &str = "Max spread exceeded";


### PR DESCRIPTION
@aidan-calculated I'm not sure we should keep the insufficient funds error given we can't reliably say that was the cause, so we just keep unknown error and set the vault to inactive if we get an unknown error, thoughts?