### PR TITLE
only continue cancel fin limit order on success

### DIFF
--- a/contracts/dca/src/handlers/after_fin_limit_order_retracted.rs
+++ b/contracts/dca/src/handlers/after_fin_limit_order_retracted.rs
@@ -10,7 +10,7 @@ use base::helpers::message_helpers::{find_first_attribute_by_key, find_first_eve
 use base::vaults::vault::VaultStatus;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{BankMsg, Coin, DepsMut, Env, Reply, Response, Uint128};
-use cosmwasm_std::{CosmosMsg, StdError, StdResult};
+use cosmwasm_std::{CosmosMsg, StdError, StdResult, SubMsgResult};
 use fin_helpers::limit_orders::create_withdraw_limit_order_sub_msg;
 
 pub fn after_fin_limit_order_retracted(
@@ -23,7 +23,7 @@ pub fn after_fin_limit_order_retracted(
     let mut response = Response::new().add_attribute("method", "fin_limit_order_retracted");
 
     match reply.result {
-        cosmwasm_std::SubMsgResult::Ok(_) => {
+        SubMsgResult::Ok(_) => {
             let limit_order_cache = LIMIT_ORDER_CACHE.load(deps.storage)?;
 
             let fin_retract_order_response = reply.result.into_result().unwrap();
@@ -102,7 +102,7 @@ pub fn after_fin_limit_order_retracted(
                 Ok(response.add_attribute("withdraw_required", "false"))
             }
         }
-        cosmwasm_std::SubMsgResult::Err(e) => Err(ContractError::CustomError {
+        SubMsgResult::Err(e) => Err(ContractError::CustomError {
             val: format!(
                 "failed to retract fin limit order for vault id: {} - {}",
                 vault.id, e

--- a/contracts/dca/src/handlers/after_fin_limit_order_withdrawn_for_cancel_vault.rs
+++ b/contracts/dca/src/handlers/after_fin_limit_order_withdrawn_for_cancel_vault.rs
@@ -10,7 +10,7 @@ use crate::{
 use base::vaults::vault::VaultStatus;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{BankMsg, Coin, DepsMut, Env, Reply, Response};
-use cosmwasm_std::{CosmosMsg, StdError, StdResult, Uint128};
+use cosmwasm_std::{CosmosMsg, StdError, StdResult, SubMsgResult, Uint128};
 
 pub fn after_fin_limit_order_withdrawn_for_cancel_vault(
     deps: DepsMut,
@@ -20,7 +20,7 @@ pub fn after_fin_limit_order_withdrawn_for_cancel_vault(
     let cache = CACHE.load(deps.storage)?;
     let vault = get_vault(deps.storage, cache.vault_id.into())?;
     match reply.result {
-        cosmwasm_std::SubMsgResult::Ok(_) => {
+        SubMsgResult::Ok(_) => {
             let limit_order_cache = LIMIT_ORDER_CACHE.load(deps.storage)?;
 
             // send assets from partially filled order to owner
@@ -64,7 +64,7 @@ pub fn after_fin_limit_order_withdrawn_for_cancel_vault(
 
             Ok(response)
         }
-        cosmwasm_std::SubMsgResult::Err(e) => Err(ContractError::CustomError {
+        SubMsgResult::Err(e) => Err(ContractError::CustomError {
             val: format!(
                 "failed to withdraw fin limit order for vault id: {} - {}",
                 vault.id, e

--- a/packages/fin-helpers/src/limit_orders.rs
+++ b/packages/fin-helpers/src/limit_orders.rs
@@ -28,7 +28,7 @@ pub fn create_withdraw_limit_order_sub_msg(
         order_idxs: Some(vec![order_idx]),
     };
 
-    SubMsg::reply_always(
+    SubMsg::reply_on_success(
         CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: pair_address.to_string(),
             msg: to_binary(&fin_withdraw_order_msg).unwrap(),
@@ -48,7 +48,7 @@ pub fn create_retract_order_sub_msg(
         amount: None,
     };
 
-    SubMsg::reply_always(
+    SubMsg::reply_on_success(
         CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: pair_address.to_string(),
             msg: to_binary(&fin_retract_order_msg).unwrap(),


### PR DESCRIPTION
From reading the docs, I think returning a custom `Err` from the after handlers might be ok(?) (i.e. it'll rollback the transaction), but if we only reply on success then it'll definitely rollback the changes if the retract/withdraw calls fail, which seems safer.

It might mean we don't get as nice error messages to the end user, but I'd sacrifice that for removing the risk of inconsistent vault balances/incorrect bank messages