### PR TITLE
restrict cancel vault to sender is owner or admin

### DIFF
--- a/contracts/dca/src/contract.rs
+++ b/contracts/dca/src/contract.rs
@@ -139,7 +139,7 @@ pub fn execute(
             target_start_time_utc_seconds,
             target_price,
         ),
-        ExecuteMsg::CancelVault { address, vault_id } => cancel_vault(deps, env, address, vault_id),
+        ExecuteMsg::CancelVault { vault_id } => cancel_vault(deps, env, info, vault_id),
         ExecuteMsg::ExecuteTrigger { trigger_id } => execute_trigger_handler(deps, env, trigger_id),
         ExecuteMsg::Deposit { address, vault_id } => deposit(deps, env, info, address, vault_id),
         ExecuteMsg::UpdateConfig {

--- a/contracts/dca/src/handlers/after_fin_limit_order_retracted.rs
+++ b/contracts/dca/src/handlers/after_fin_limit_order_retracted.rs
@@ -1,11 +1,9 @@
 use crate::contract::AFTER_FIN_LIMIT_ORDER_WITHDRAWN_FOR_CANCEL_VAULT_REPLY_ID;
 use crate::error::ContractError;
 use crate::state::cache::{CACHE, LIMIT_ORDER_CACHE};
-use crate::state::events::create_event;
 use crate::state::triggers::delete_trigger;
 use crate::state::vaults::{get_vault, update_vault};
 use crate::vault::Vault;
-use base::events::event::{EventBuilder, EventData};
 use base::helpers::message_helpers::{find_first_attribute_by_key, find_first_event_by_type};
 use base::vaults::vault::VaultStatus;
 #[cfg(not(feature = "library"))]
@@ -15,7 +13,7 @@ use fin_helpers::limit_orders::create_withdraw_limit_order_sub_msg;
 
 pub fn after_fin_limit_order_retracted(
     deps: DepsMut,
-    env: Env,
+    _env: Env,
     reply: Reply,
 ) -> Result<Response, ContractError> {
     let cache = CACHE.load(deps.storage)?;

--- a/contracts/dca/src/handlers/cancel_vault.rs
+++ b/contracts/dca/src/handlers/cancel_vault.rs
@@ -11,22 +11,21 @@ use crate::vault::Vault;
 use base::events::event::{EventBuilder, EventData};
 use base::triggers::trigger::TriggerConfiguration;
 use base::vaults::vault::VaultStatus;
-use cosmwasm_std::{Addr, Coin, CosmosMsg, Env, StdError, StdResult};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{BankMsg, DepsMut, Response, Uint128};
+use cosmwasm_std::{Coin, CosmosMsg, Env, MessageInfo, StdError, StdResult};
 use fin_helpers::limit_orders::create_retract_order_sub_msg;
 use fin_helpers::queries::query_order_details;
 
 pub fn cancel_vault(
     deps: DepsMut,
     env: Env,
-    address: Addr,
+    info: MessageInfo,
     vault_id: Uint128,
 ) -> Result<Response, ContractError> {
-    deps.api.addr_validate(&address.to_string())?;
     let vault = get_vault(deps.storage, vault_id)?;
 
-    assert_sender_is_admin_or_vault_owner(deps.storage, vault.owner.clone(), address.clone())?;
+    assert_sender_is_admin_or_vault_owner(deps.storage, vault.owner.clone(), info.sender.clone())?;
     assert_vault_is_not_cancelled(&vault)?;
 
     create_event(

--- a/contracts/dca/src/msg.rs
+++ b/contracts/dca/src/msg.rs
@@ -53,7 +53,6 @@ pub enum ExecuteMsg {
         vault_id: Uint128,
     },
     CancelVault {
-        address: Addr,
         vault_id: Uint128,
     },
     ExecuteTrigger {

--- a/contracts/dca/src/tests/cancel_vault_tests.rs
+++ b/contracts/dca/src/tests/cancel_vault_tests.rs
@@ -51,7 +51,6 @@ fn when_vault_has_unfilled_fin_limit_order_trigger_should_update_address_balance
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
                 vault_id: mock.vault_ids.get("fin").unwrap().to_owned(),
             },
             &[],
@@ -91,7 +90,6 @@ fn when_vault_has_unfilled_fin_limit_order_trigger_should_publish_events() {
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
                 vault_id: mock.vault_ids.get("fin").unwrap().to_owned(),
             },
             &[],
@@ -132,7 +130,6 @@ fn when_vault_has_unfilled_fin_limit_order_trigger_should_cancel_vault() {
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
                 vault_id: mock.vault_ids.get("fin").unwrap().to_owned(),
             },
             &[],
@@ -176,7 +173,6 @@ fn when_vault_has_unfilled_fin_limit_order_trigger_should_empty_vault_balance() 
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
                 vault_id: mock.vault_ids.get("fin").unwrap().to_owned(),
             },
             &[],
@@ -245,10 +241,7 @@ fn when_vault_has_partially_filled_price_trigger_should_update_address_balances(
         .execute_contract(
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
-            &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
-                vault_id,
-            },
+            &ExecuteMsg::CancelVault { vault_id },
             &[],
         )
         .unwrap();
@@ -291,10 +284,7 @@ fn when_vault_has_partially_filled_price_trigger_should_publish_events() {
         .execute_contract(
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
-            &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
-                vault_id,
-            },
+            &ExecuteMsg::CancelVault { vault_id },
             &[],
         )
         .unwrap();
@@ -332,10 +322,7 @@ fn when_vault_has_partially_filled_price_trigger_should_empty_vault_balance() {
         .execute_contract(
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
-            &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
-                vault_id,
-            },
+            &ExecuteMsg::CancelVault { vault_id },
             &[],
         )
         .unwrap();
@@ -376,10 +363,7 @@ fn when_vault_has_partially_filled_price_trigger_should_cancel_vault() {
         .execute_contract(
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
-            &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
-                vault_id,
-            },
+            &ExecuteMsg::CancelVault { vault_id },
             &[],
         )
         .unwrap();
@@ -438,10 +422,7 @@ fn when_vault_has_time_trigger_should_update_address_balances() {
         .execute_contract(
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
-            &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
-                vault_id,
-            },
+            &ExecuteMsg::CancelVault { vault_id },
             &[],
         )
         .unwrap();
@@ -481,10 +462,7 @@ fn when_vault_has_time_trigger_should_publish_events() {
         .execute_contract(
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
-            &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
-                vault_id,
-            },
+            &ExecuteMsg::CancelVault { vault_id },
             &[],
         )
         .unwrap();
@@ -523,10 +501,7 @@ fn when_vault_has_time_trigger_should_cancel_vault() {
         .execute_contract(
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
-            &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
-                vault_id,
-            },
+            &ExecuteMsg::CancelVault { vault_id },
             &[],
         )
         .unwrap();
@@ -568,10 +543,7 @@ fn when_vault_has_time_trigger_should_empty_vault_balance() {
         .execute_contract(
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
-            &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
-                vault_id,
-            },
+            &ExecuteMsg::CancelVault { vault_id },
             &[],
         )
         .unwrap();
@@ -611,7 +583,6 @@ fn on_already_cancelled_vault_should_fail() {
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
                 vault_id: mock.vault_ids.get("fin").unwrap().to_owned(),
             },
             &[],
@@ -624,7 +595,6 @@ fn on_already_cancelled_vault_should_fail() {
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
                 vault_id: mock.vault_ids.get("fin").unwrap().to_owned(),
             },
             &[],
@@ -635,4 +605,34 @@ fn on_already_cancelled_vault_should_fail() {
         .root_cause()
         .to_string()
         .contains("Error: vault is already cancelled"));
+}
+
+#[test]
+fn for_vault_with_different_onwer_should_fail() {
+    let user_address = Addr::unchecked(USER);
+    let user_balance = TEN;
+    let swap_amount = ONE;
+    let mut mock = MockApp::new(fin_contract_unfilled_limit_order())
+        .with_funds_for(&user_address, user_balance, DENOM_UKUJI)
+        .with_vault_with_unfilled_fin_limit_price_trigger(
+            &user_address,
+            None,
+            Coin::new(user_balance.into(), DENOM_UKUJI),
+            swap_amount,
+            "fin",
+        );
+
+    let response = mock
+        .app
+        .execute_contract(
+            Addr::unchecked("not-the-owner"),
+            mock.dca_contract_address.clone(),
+            &ExecuteMsg::CancelVault {
+                vault_id: mock.vault_ids.get("fin").unwrap().to_owned(),
+            },
+            &[],
+        )
+        .unwrap_err();
+
+    assert_eq!(response.root_cause().to_string(), "Unauthorized");
 }

--- a/contracts/dca/src/tests/contract_tests.rs
+++ b/contracts/dca/src/tests/contract_tests.rs
@@ -420,7 +420,6 @@ fn cancel_vault_with_valid_inputs_should_succeed() {
     .unwrap();
 
     let cancel_vault_execute_message = ExecuteMsg::CancelVault {
-        address: Addr::unchecked(VALID_ADDRESS_THREE),
         vault_id: Uint128::new(1),
     };
 

--- a/contracts/dca/src/tests/deposit_tests.rs
+++ b/contracts/dca/src/tests/deposit_tests.rs
@@ -292,10 +292,7 @@ fn when_vault_is_cancelled_should_fail() {
         .execute_contract(
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
-            &ExecuteMsg::CancelVault {
-                address: user_address.clone(),
-                vault_id,
-            },
+            &ExecuteMsg::CancelVault { vault_id },
             &[],
         )
         .unwrap();


### PR DESCRIPTION
@aidan-calculated we may as well remove address from cancel vault given we are validating on info.sender now