### PR TITLE
remove trigger from get top level vault response

### DIFF
--- a/contracts/dca/src/handlers/get_vault.rs
+++ b/contracts/dca/src/handlers/get_vault.rs
@@ -1,7 +1,4 @@
-use crate::{
-    msg::VaultResponse,
-    state::{triggers::get_trigger, vaults::get_vault as fetch_vault},
-};
+use crate::{msg::VaultResponse, state::vaults::get_vault as fetch_vault};
 use cosmwasm_std::{Addr, Deps, StdError, StdResult, Uint128};
 
 pub fn get_vault(deps: Deps, address: Addr, vault_id: Uint128) -> StdResult<VaultResponse> {
@@ -15,6 +12,5 @@ pub fn get_vault(deps: Deps, address: Addr, vault_id: Uint128) -> StdResult<Vaul
 
     Ok(VaultResponse {
         vault: vault.clone(),
-        trigger: get_trigger(deps.storage, vault.id.into())?,
     })
 }

--- a/contracts/dca/src/msg.rs
+++ b/contracts/dca/src/msg.rs
@@ -1,6 +1,6 @@
 use base::events::event::Event;
 use base::pair::Pair;
-use base::triggers::trigger::{TimeInterval, Trigger};
+use base::triggers::trigger::TimeInterval;
 use base::vaults::vault::{Destination, PositionType, VaultStatus};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal, Decimal256, Uint128, Uint64};
@@ -116,7 +116,6 @@ pub struct TriggerIdsResponse {
 #[cw_serde]
 pub struct VaultResponse {
     pub vault: Vault,
-    pub trigger: Option<Trigger>,
 }
 
 #[cw_serde]


### PR DESCRIPTION
to be included once the FE has stopped using the top level trigger in the get vault response