### PR TITLE
use Decimal rather than Decimal256

### DIFF
--- a/contracts/dca/src/handlers/create_vault.rs
+++ b/contracts/dca/src/handlers/create_vault.rs
@@ -34,7 +34,7 @@ pub fn create_vault(
     mut destinations: Vec<Destination>,
     pair_address: Addr,
     position_type: Option<PositionType>,
-    slippage_tolerance: Option<Decimal256>,
+    slippage_tolerance: Option<Decimal>,
     minimum_receive_amount: Option<Uint128>,
     swap_amount: Uint128,
     time_interval: TimeInterval,

--- a/contracts/dca/src/msg.rs
+++ b/contracts/dca/src/msg.rs
@@ -41,7 +41,7 @@ pub enum ExecuteMsg {
         destinations: Option<Vec<Destination>>,
         pair_address: Addr,
         position_type: Option<PositionType>,
-        slippage_tolerance: Option<Decimal256>,
+        slippage_tolerance: Option<Decimal>,
         minimum_receive_amount: Option<Uint128>,
         swap_amount: Uint128,
         time_interval: TimeInterval,

--- a/contracts/dca/src/state/vaults.rs
+++ b/contracts/dca/src/state/vaults.rs
@@ -4,7 +4,7 @@ use base::{
     vaults::vault::{Destination, VaultStatus},
 };
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Coin, Decimal256, StdResult, Storage, Timestamp, Uint128};
+use cosmwasm_std::{Addr, Coin, Decimal, StdResult, Storage, Timestamp, Uint128};
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, Item, UniqueIndex};
 
 use crate::types::{vault::Vault, vault_builder::VaultBuilder};
@@ -24,7 +24,7 @@ struct VaultDTO {
     pub balance: Coin,
     pub pair_address: Addr,
     pub swap_amount: Uint128,
-    pub slippage_tolerance: Option<Decimal256>,
+    pub slippage_tolerance: Option<Decimal>,
     pub minimum_receive_amount: Option<Uint128>,
     pub time_interval: TimeInterval,
     pub started_at: Option<Timestamp>,

--- a/contracts/dca/src/tests/create_vault_tests.rs
+++ b/contracts/dca/src/tests/create_vault_tests.rs
@@ -710,7 +710,7 @@ fn with_immediate_time_trigger_should_publish_events() {
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    asset_price: Decimal256::from_str("1.0").unwrap(),
+                    asset_price: Decimal::from_str("1.0").unwrap(),
                 },
             )
             .build(3),

--- a/contracts/dca/src/tests/execute_trigger_tests.rs
+++ b/contracts/dca/src/tests/execute_trigger_tests.rs
@@ -14,7 +14,7 @@ use crate::tests::mocks::{
 use base::events::event::{EventBuilder, EventData};
 use base::helpers::math_helpers::checked_mul;
 use base::vaults::vault::{Destination, PostExecutionAction, VaultStatus};
-use cosmwasm_std::{Addr, Coin, Decimal, Decimal256, Uint128};
+use cosmwasm_std::{Addr, Coin, Decimal, Uint128};
 use cw_multi_test::Executor;
 
 #[test]
@@ -240,7 +240,7 @@ fn for_filled_fin_limit_order_trigger_should_publish_events() {
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    asset_price: Decimal256::from_str("1.0").unwrap(),
+                    asset_price: Decimal::from_str("1.0").unwrap(),
                 },
             )
             .build(3),
@@ -810,7 +810,7 @@ fn for_ready_time_trigger_should_create_events() {
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    asset_price: Decimal256::from_str("1.0").unwrap(),
+                    asset_price: Decimal::from_str("1.0").unwrap(),
                 },
             )
             .build(3),
@@ -1027,7 +1027,7 @@ fn for_ready_time_trigger_within_price_threshold_should_succeed() {
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    asset_price: Decimal256::from_str("1.0").unwrap(),
+                    asset_price: Decimal::from_str("1.0").unwrap(),
                 },
             )
             .build(3),
@@ -1120,7 +1120,7 @@ fn for_ready_time_trigger_for_fin_buy_less_than_minimum_receive_amount_should_sk
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    asset_price: Decimal256::from_str("1.0").unwrap(),
+                    asset_price: Decimal::from_str("1.0").unwrap(),
                 },
             )
             .build(3),
@@ -1129,7 +1129,7 @@ fn for_ready_time_trigger_for_fin_buy_less_than_minimum_receive_amount_should_sk
                 mock.app.block_info(),
                 EventData::DCAVaultExecutionSkipped {
                     reason: base::events::event::ExecutionSkippedReason::PriceThresholdExceeded {
-                        price: Decimal256::from_str("1.0").unwrap(),
+                        price: Decimal::from_str("1.0").unwrap(),
                     },
                 },
             )
@@ -1189,7 +1189,7 @@ fn for_ready_time_trigger_for_fin_sell_less_than_minimum_receive_amount_should_s
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    asset_price: Decimal256::from_str("1.0").unwrap(),
+                    asset_price: Decimal::from_str("1.0").unwrap(),
                 },
             )
             .build(3),
@@ -1198,7 +1198,7 @@ fn for_ready_time_trigger_for_fin_sell_less_than_minimum_receive_amount_should_s
                 mock.app.block_info(),
                 EventData::DCAVaultExecutionSkipped {
                     reason: base::events::event::ExecutionSkippedReason::PriceThresholdExceeded {
-                        price: Decimal256::from_str("1.0").unwrap(),
+                        price: Decimal::from_str("1.0").unwrap(),
                     },
                 },
             )
@@ -1819,7 +1819,7 @@ fn until_vault_is_empty_should_create_events() {
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    asset_price: Decimal256::from_str("1.0").unwrap(),
+                    asset_price: Decimal::from_str("1.0").unwrap(),
                 },
             )
             .build(3),
@@ -1839,7 +1839,7 @@ fn until_vault_is_empty_should_create_events() {
                 EventData::DCAVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
-                    asset_price: Decimal256::from_str("1.0").unwrap(),
+                    asset_price: Decimal::from_str("1.0").unwrap(),
                 },
             )
             .build(5),

--- a/contracts/dca/src/types/vault.rs
+++ b/contracts/dca/src/types/vault.rs
@@ -4,7 +4,7 @@ use base::{
     vaults::vault::{Destination, PositionType, VaultStatus},
 };
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Coin, Decimal256, Timestamp, Uint128};
+use cosmwasm_std::{Addr, Coin, Decimal, Timestamp, Uint128};
 
 #[cw_serde]
 pub struct Vault {
@@ -17,7 +17,7 @@ pub struct Vault {
     pub balance: Coin,
     pub pair: Pair,
     pub swap_amount: Uint128,
-    pub slippage_tolerance: Option<Decimal256>,
+    pub slippage_tolerance: Option<Decimal>,
     pub minimum_receive_amount: Option<Uint128>,
     pub time_interval: TimeInterval,
     pub started_at: Option<Timestamp>,
@@ -55,19 +55,19 @@ impl Vault {
         }
     }
 
-    pub fn price_threshold_exceeded(&self, price: Decimal256) -> bool {
+    pub fn price_threshold_exceeded(&self, price: Decimal) -> bool {
         if let Some(minimum_receive_amount) = self.minimum_receive_amount {
             let receive_amount_at_price = match self.get_position_type() {
-                PositionType::Enter => Decimal256::from_ratio(self.swap_amount, Uint128::one())
+                PositionType::Enter => Decimal::from_ratio(self.swap_amount, Uint128::one())
                     .checked_div(price)
                     .expect("current fin price should be > 0.0"),
-                PositionType::Exit => Decimal256::from_ratio(self.swap_amount, Uint128::one())
+                PositionType::Exit => Decimal::from_ratio(self.swap_amount, Uint128::one())
                     .checked_mul(price)
                     .expect("expected receive amount should be valid"),
             };
 
             let minimum_receive_amount =
-                Decimal256::from_ratio(minimum_receive_amount, Uint128::one());
+                Decimal::from_ratio(minimum_receive_amount, Uint128::one());
 
             return receive_amount_at_price < minimum_receive_amount;
         }
@@ -103,7 +103,7 @@ mod price_threshold_exceeded_tests {
         let vault = vault_with(Uint128::new(100), Uint128::new(50), PositionType::Enter);
 
         assert_eq!(
-            vault.price_threshold_exceeded(Decimal256::from_str("1.9").unwrap()),
+            vault.price_threshold_exceeded(Decimal::from_str("1.9").unwrap()),
             false
         );
     }
@@ -113,7 +113,7 @@ mod price_threshold_exceeded_tests {
         let vault = vault_with(Uint128::new(100), Uint128::new(50), PositionType::Enter);
 
         assert_eq!(
-            vault.price_threshold_exceeded(Decimal256::from_str("2.0").unwrap()),
+            vault.price_threshold_exceeded(Decimal::from_str("2.0").unwrap()),
             false
         );
     }
@@ -123,7 +123,7 @@ mod price_threshold_exceeded_tests {
         let vault = vault_with(Uint128::new(100), Uint128::new(50), PositionType::Enter);
 
         assert_eq!(
-            vault.price_threshold_exceeded(Decimal256::from_str("2.1").unwrap()),
+            vault.price_threshold_exceeded(Decimal::from_str("2.1").unwrap()),
             true
         );
     }
@@ -133,7 +133,7 @@ mod price_threshold_exceeded_tests {
         let vault = vault_with(Uint128::new(100), Uint128::new(50), PositionType::Exit);
 
         assert_eq!(
-            vault.price_threshold_exceeded(Decimal256::from_str("0.51").unwrap()),
+            vault.price_threshold_exceeded(Decimal::from_str("0.51").unwrap()),
             false
         );
     }
@@ -143,7 +143,7 @@ mod price_threshold_exceeded_tests {
         let vault = vault_with(Uint128::new(100), Uint128::new(50), PositionType::Exit);
 
         assert_eq!(
-            vault.price_threshold_exceeded(Decimal256::from_str("0.50").unwrap()),
+            vault.price_threshold_exceeded(Decimal::from_str("0.50").unwrap()),
             false
         );
     }
@@ -153,7 +153,7 @@ mod price_threshold_exceeded_tests {
         let vault = vault_with(Uint128::new(100), Uint128::new(50), PositionType::Exit);
 
         assert_eq!(
-            vault.price_threshold_exceeded(Decimal256::from_str("0.49").unwrap()),
+            vault.price_threshold_exceeded(Decimal::from_str("0.49").unwrap()),
             true
         );
     }

--- a/contracts/dca/src/types/vault_builder.rs
+++ b/contracts/dca/src/types/vault_builder.rs
@@ -3,7 +3,7 @@ use base::{
     triggers::trigger::TimeInterval,
     vaults::vault::{Destination, PositionType, VaultStatus},
 };
-use cosmwasm_std::{coin, Addr, Coin, Decimal256, Timestamp, Uint128};
+use cosmwasm_std::{coin, Addr, Coin, Decimal, Timestamp, Uint128};
 
 use super::vault::Vault;
 
@@ -17,7 +17,7 @@ pub struct VaultBuilder {
     pub pair: Pair,
     pub swap_amount: Uint128,
     pub position_type: Option<PositionType>,
-    pub slippage_tolerance: Option<Decimal256>,
+    pub slippage_tolerance: Option<Decimal>,
     pub minimum_receive_amount: Option<Uint128>,
     pub time_interval: TimeInterval,
     pub started_at: Option<Timestamp>,
@@ -34,7 +34,7 @@ impl VaultBuilder {
         pair: Pair,
         swap_amount: Uint128,
         position_type: Option<PositionType>,
-        slippage_tolerance: Option<Decimal256>,
+        slippage_tolerance: Option<Decimal>,
         minimum_receive_amount: Option<Uint128>,
         time_interval: TimeInterval,
         started_at: Option<Timestamp>,

--- a/packages/base/src/events/event.rs
+++ b/packages/base/src/events/event.rs
@@ -1,10 +1,10 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{BlockInfo, Coin, Decimal256, Timestamp, Uint128};
+use cosmwasm_std::{BlockInfo, Coin, Decimal, Timestamp, Uint128};
 
 #[cw_serde]
 pub enum ExecutionSkippedReason {
     SlippageToleranceExceeded,
-    PriceThresholdExceeded { price: Decimal256 },
+    PriceThresholdExceeded { price: Decimal },
     UnknownFailure,
 }
 
@@ -17,7 +17,7 @@ pub enum EventData {
     DCAVaultExecutionTriggered {
         base_denom: String,
         quote_denom: String,
-        asset_price: Decimal256,
+        asset_price: Decimal,
     },
     DCAVaultExecutionCompleted {
         sent: Coin,

--- a/packages/fin-helpers/src/msg.rs
+++ b/packages/fin-helpers/src/msg.rs
@@ -1,10 +1,10 @@
-use cosmwasm_std::{Decimal256, Uint128, Uint256};
+use cosmwasm_std::{Decimal, Uint128};
 use serde::{Deserialize, Serialize};
 // use serde instead of cw_serde so allow for deserialisation of unknown fields
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct FINPoolResponseWithoutDenom {
-    pub quote_price: Decimal256,
-    pub total_offer_amount: Uint256,
+    pub quote_price: Decimal,
+    pub total_offer_amount: Uint128,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/packages/fin-helpers/src/queries.rs
+++ b/packages/fin-helpers/src/queries.rs
@@ -1,9 +1,9 @@
-use cosmwasm_std::{Addr, Decimal256, QuerierWrapper, Uint128};
+use cosmwasm_std::{Addr, Decimal, QuerierWrapper, Uint128};
 use kujira::fin::QueryMsg as FINQueryMsg;
 
 use crate::msg::{FINBookResponse, FINOrderResponseWithoutDenom};
 
-pub fn query_base_price(querier: QuerierWrapper, pair_address: Addr) -> Decimal256 {
+pub fn query_base_price(querier: QuerierWrapper, pair_address: Addr) -> Decimal {
     let book_query_msg = FINQueryMsg::Book {
         limit: Some(1),
         offset: None,
@@ -16,7 +16,7 @@ pub fn query_base_price(querier: QuerierWrapper, pair_address: Addr) -> Decimal2
     book_response.base[0].quote_price
 }
 
-pub fn query_quote_price(querier: QuerierWrapper, pair_address: Addr) -> Decimal256 {
+pub fn query_quote_price(querier: QuerierWrapper, pair_address: Addr) -> Decimal {
     let book_query_msg = FINQueryMsg::Book {
         limit: Some(1),
         offset: None,

--- a/packages/fin-helpers/src/swaps.rs
+++ b/packages/fin-helpers/src/swaps.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, Addr, Coin, CosmosMsg, Decimal256, SubMsg, WasmMsg};
+use cosmwasm_std::{to_binary, Addr, Coin, CosmosMsg, Decimal, Decimal256, SubMsg, WasmMsg};
 use kujira::fin::ExecuteMsg as FINExecuteMsg;
 
 pub fn create_fin_swap_without_slippage(
@@ -31,14 +31,14 @@ pub fn create_fin_swap_without_slippage(
 
 pub fn create_fin_swap_with_slippage(
     pair_address: Addr,
-    belief_price: Decimal256,
-    max_spread: Decimal256,
+    belief_price: Decimal,
+    max_spread: Decimal,
     coin_to_send_with_message: Coin,
     reply_id: u64,
 ) -> SubMsg {
     let fin_swap_msg = FINExecuteMsg::Swap {
-        belief_price: Some(belief_price),
-        max_spread: Some(max_spread),
+        belief_price: Some(Decimal256::from(belief_price)),
+        max_spread: Some(Decimal256::from(max_spread)),
         offer_asset: None,
         to: None,
     };


### PR DESCRIPTION
Proposal: use `Decimal` rather than `Decimal256` for price values given that `Coin` amounts are in `Uint128` which is far easier to work with from `Decimal`s 