### PR TITLE
remove unneeded delete

### DIFF
--- a/contracts/dca/src/handlers/after_fin_limit_order_submitted.rs
+++ b/contracts/dca/src/handlers/after_fin_limit_order_submitted.rs
@@ -1,6 +1,6 @@
 use crate::error::ContractError;
 use crate::state::cache::CACHE;
-use crate::state::triggers::{delete_trigger, get_trigger, save_trigger};
+use crate::state::triggers::{get_trigger, save_trigger};
 use base::helpers::message_helpers::get_attribute_in_event;
 use base::triggers::trigger::{Trigger, TriggerConfiguration};
 #[cfg(not(feature = "library"))]


### PR DESCRIPTION
- as suggested by the audit finding # 14 - we can write over this trigger instead of deleting it