### PR TITLE
make enums more consistent/readable

### DIFF
--- a/contracts/dca/src/handlers/after_fin_limit_order_submitted.rs
+++ b/contracts/dca/src/handlers/after_fin_limit_order_submitted.rs
@@ -25,12 +25,12 @@ pub fn after_fin_limit_order_submitted(
                 .expect(format!("fin limit order trigger for vault {:?}", cache.vault_id).as_str());
 
             match trigger.configuration {
-                TriggerConfiguration::FINLimitOrder { target_price, .. } => {
+                TriggerConfiguration::FinLimitOrder { target_price, .. } => {
                     save_trigger(
                         deps.storage,
                         Trigger {
                             vault_id: cache.vault_id,
-                            configuration: TriggerConfiguration::FINLimitOrder {
+                            configuration: TriggerConfiguration::FinLimitOrder {
                                 order_idx: Some(order_idx),
                                 target_price,
                             },

--- a/contracts/dca/src/handlers/after_fin_limit_order_withdrawn_for_execute_trigger.rs
+++ b/contracts/dca/src/handlers/after_fin_limit_order_withdrawn_for_execute_trigger.rs
@@ -155,7 +155,7 @@ pub fn after_fin_limit_order_withdrawn_for_execute_vault(
                 EventBuilder::new(
                     vault.id,
                     env.block,
-                    EventData::DCAVaultExecutionCompleted {
+                    EventData::DcaVaultExecutionCompleted {
                         sent: Coin {
                             denom: vault.get_swap_denom().clone(),
                             amount: limit_order_cache.original_offer_amount,

--- a/contracts/dca/src/handlers/after_fin_swap.rs
+++ b/contracts/dca/src/handlers/after_fin_swap.rs
@@ -190,7 +190,7 @@ pub fn after_fin_swap(deps: DepsMut, env: Env, reply: Reply) -> Result<Response,
                 EventBuilder::new(
                     vault.id,
                     env.block,
-                    EventData::DCAVaultExecutionCompleted {
+                    EventData::DcaVaultExecutionCompleted {
                         sent: coin_sent.clone(),
                         received: coin_received.clone(),
                         fee: execution_fee,
@@ -234,7 +234,7 @@ pub fn after_fin_swap(deps: DepsMut, env: Env, reply: Reply) -> Result<Response,
                 EventBuilder::new(
                     vault.id,
                     env.block.to_owned(),
-                    EventData::DCAVaultExecutionSkipped {
+                    EventData::DcaVaultExecutionSkipped {
                         reason: execution_skipped_reason.clone(),
                     },
                 ),

--- a/contracts/dca/src/handlers/after_z_delegation.rs
+++ b/contracts/dca/src/handlers/after_z_delegation.rs
@@ -35,7 +35,7 @@ pub fn after_z_delegation(
                 EventBuilder::new(
                     vault.id,
                     env.block,
-                    EventData::DCAVaultZDelegationSucceeded {
+                    EventData::DcaVaultZDelegationSucceeded {
                         validator_address,
                         delegation: delegation_amount,
                     },

--- a/contracts/dca/src/handlers/cancel_vault.rs
+++ b/contracts/dca/src/handlers/cancel_vault.rs
@@ -30,7 +30,7 @@ pub fn cancel_vault(
 
     create_event(
         deps.storage,
-        EventBuilder::new(vault.id, env.block, EventData::DCAVaultCancelled),
+        EventBuilder::new(vault.id, env.block, EventData::DcaVaultCancelled),
     )?;
 
     match vault
@@ -39,7 +39,7 @@ pub fn cancel_vault(
         .expect(format!("trigger for vault id {}", vault.id).as_str())
     {
         TriggerConfiguration::Time { .. } => cancel_time_trigger(deps, vault),
-        TriggerConfiguration::FINLimitOrder { order_idx, .. } => {
+        TriggerConfiguration::FinLimitOrder { order_idx, .. } => {
             cancel_fin_limit_order_trigger(deps, order_idx.unwrap(), vault)
         }
     }

--- a/contracts/dca/src/handlers/create_vault.rs
+++ b/contracts/dca/src/handlers/create_vault.rs
@@ -117,7 +117,7 @@ pub fn create_vault(
 
     create_event(
         deps.storage,
-        EventBuilder::new(vault.id, env.block.clone(), EventData::DCAVaultCreated),
+        EventBuilder::new(vault.id, env.block.clone(), EventData::DcaVaultCreated {}),
     )?;
 
     create_event(
@@ -125,7 +125,7 @@ pub fn create_vault(
         EventBuilder::new(
             vault.id,
             env.block.clone(),
-            EventData::DCAVaultFundsDeposited {
+            EventData::DcaVaultFundsDeposited {
                 amount: info.funds[0].clone(),
             },
         ),
@@ -201,7 +201,7 @@ fn create_fin_limit_order_trigger(
         deps.storage,
         Trigger {
             vault_id: vault.id,
-            configuration: TriggerConfiguration::FINLimitOrder {
+            configuration: TriggerConfiguration::FinLimitOrder {
                 order_idx: None,
                 target_price,
             },

--- a/contracts/dca/src/handlers/deposit.rs
+++ b/contracts/dca/src/handlers/deposit.rs
@@ -66,7 +66,7 @@ pub fn deposit(
         EventBuilder::new(
             vault.id,
             env.block,
-            EventData::DCAVaultFundsDeposited {
+            EventData::DcaVaultFundsDeposited {
                 amount: info.funds[0].clone(),
             },
         ),

--- a/contracts/dca/src/handlers/execute_trigger.rs
+++ b/contracts/dca/src/handlers/execute_trigger.rs
@@ -65,7 +65,7 @@ pub fn execute_trigger(
         EventBuilder::new(
             vault.id,
             env.block.to_owned(),
-            EventData::DCAVaultExecutionTriggered {
+            EventData::DcaVaultExecutionTriggered {
                 base_denom: vault.pair.base_denom.clone(),
                 quote_denom: vault.pair.quote_denom.clone(),
                 asset_price: current_fin_price.clone(),
@@ -87,7 +87,7 @@ pub fn execute_trigger(
                     EventBuilder::new(
                         vault.id,
                         env.block.to_owned(),
-                        EventData::DCAVaultExecutionSkipped {
+                        EventData::DcaVaultExecutionSkipped {
                             reason: ExecutionSkippedReason::PriceThresholdExceeded {
                                 price: current_fin_price,
                             },
@@ -139,7 +139,7 @@ pub fn execute_trigger(
 
             Ok(response.add_submessage(fin_swap_msg))
         }
-        TriggerConfiguration::FINLimitOrder { order_idx, .. } => {
+        TriggerConfiguration::FinLimitOrder { order_idx, .. } => {
             if let Some(order_idx) = order_idx {
                 let (offer_amount, original_offer_amount, filled) =
                     query_order_details(deps.querier, vault.pair.address.clone(), order_idx);

--- a/contracts/dca/src/state/triggers.rs
+++ b/contracts/dca/src/state/triggers.rs
@@ -30,7 +30,7 @@ pub fn save_trigger(store: &mut dyn Storage, trigger: Trigger) -> StdResult<Uint
                 }
             }
         }
-        TriggerConfiguration::FINLimitOrder { order_idx, .. } => {
+        TriggerConfiguration::FinLimitOrder { order_idx, .. } => {
             if order_idx.is_some() {
                 TRIGGER_ID_BY_FIN_LIMIT_ORDER_IDX.save(
                     store,
@@ -61,7 +61,7 @@ pub fn delete_trigger(store: &mut dyn Storage, vault_id: Uint128) -> StdResult<U
                 TRIGGER_IDS_BY_TARGET_TIME.save(store, target_time.seconds(), &triggers)?;
             }
         }
-        TriggerConfiguration::FINLimitOrder { order_idx, .. } => {
+        TriggerConfiguration::FinLimitOrder { order_idx, .. } => {
             if order_idx.is_some() {
                 TRIGGER_ID_BY_FIN_LIMIT_ORDER_IDX.remove(store, order_idx.unwrap().u128());
             }

--- a/contracts/dca/src/tests/after_fin_limit_order_withdrawn_for_execute_vault_tests.rs
+++ b/contracts/dca/src/tests/after_fin_limit_order_withdrawn_for_execute_vault_tests.rs
@@ -308,7 +308,7 @@ fn after_successful_withdrawal_creates_execution_completed_event() {
         &EventBuilder::new(
             vault.id,
             env.block,
-            EventData::DCAVaultExecutionCompleted {
+            EventData::DcaVaultExecutionCompleted {
                 sent: vault.get_swap_amount(),
                 received: Coin::new(
                     vault.get_swap_amount().amount.into(),

--- a/contracts/dca/src/tests/after_fin_swap_tests.rs
+++ b/contracts/dca/src/tests/after_fin_swap_tests.rs
@@ -188,7 +188,7 @@ fn with_insufficient_funds_publishes_unknown_failure_event() {
         &EventBuilder::new(
             vault_id,
             env.block.clone(),
-            EventData::DCAVaultExecutionSkipped {
+            EventData::DcaVaultExecutionSkipped {
                 reason: ExecutionSkippedReason::UnknownFailure
             }
         )
@@ -309,7 +309,7 @@ fn with_slippage_failure_publishes_execution_failed_event() {
         &EventBuilder::new(
             vault_id,
             env.block.clone(),
-            EventData::DCAVaultExecutionSkipped {
+            EventData::DcaVaultExecutionSkipped {
                 reason: ExecutionSkippedReason::SlippageToleranceExceeded
             }
         )

--- a/contracts/dca/src/tests/cancel_vault_tests.rs
+++ b/contracts/dca/src/tests/cancel_vault_tests.rs
@@ -104,7 +104,7 @@ fn when_vault_has_unfilled_fin_limit_order_trigger_should_publish_events() {
         &[EventBuilder::new(
             vault_id,
             mock.app.block_info(),
-            EventData::DCAVaultCancelled,
+            EventData::DcaVaultCancelled,
         )
         .build(3)],
     );
@@ -289,7 +289,7 @@ fn when_vault_has_partially_filled_price_trigger_should_publish_events() {
         &[EventBuilder::new(
             vault_id,
             mock.app.block_info(),
-            EventData::DCAVaultCancelled,
+            EventData::DcaVaultCancelled,
         )
         .build(3)],
     );
@@ -461,7 +461,7 @@ fn when_vault_has_time_trigger_should_publish_events() {
         &[EventBuilder::new(
             vault_id,
             mock.app.block_info(),
-            EventData::DCAVaultCancelled,
+            EventData::DcaVaultCancelled,
         )
         .build(3)],
     );

--- a/contracts/dca/src/tests/create_vault_tests.rs
+++ b/contracts/dca/src/tests/create_vault_tests.rs
@@ -197,7 +197,7 @@ fn with_price_trigger_for_fin_buy_should_create_correct_trigger() {
         .unwrap();
 
     match vault_response.vault.trigger.unwrap() {
-        TriggerConfiguration::FINLimitOrder {
+        TriggerConfiguration::FinLimitOrder {
             target_price,
             order_idx,
         } => {
@@ -254,7 +254,7 @@ fn with_price_trigger_for_fin_sell_should_create_correct_trigger() {
         .unwrap();
 
     match vault_response.vault.trigger.unwrap() {
-        TriggerConfiguration::FINLimitOrder {
+        TriggerConfiguration::FinLimitOrder {
             target_price,
             order_idx,
         } => {
@@ -302,7 +302,12 @@ fn with_price_trigger_should_publish_vault_created_event() {
     assert_events_published(
         &mock,
         vault_id,
-        &[EventBuilder::new(vault_id, mock.app.block_info(), EventData::DCAVaultCreated).build(1)],
+        &[EventBuilder::new(
+            vault_id,
+            mock.app.block_info(),
+            EventData::DcaVaultCreated {},
+        )
+        .build(1)],
     );
 }
 
@@ -346,7 +351,7 @@ fn with_price_trigger_should_publish_funds_deposited_event() {
         &[EventBuilder::new(
             vault_id,
             mock.app.block_info(),
-            EventData::DCAVaultFundsDeposited {
+            EventData::DcaVaultFundsDeposited {
                 amount: Coin::new(vault_deposit.into(), DENOM_UKUJI),
             },
         )
@@ -502,7 +507,12 @@ fn with_price_trigger_twice_for_user_should_succeed() {
     assert_events_published(
         &mock,
         vault_id,
-        &[EventBuilder::new(vault_id, mock.app.block_info(), EventData::DCAVaultCreated).build(3)],
+        &[EventBuilder::new(
+            vault_id,
+            mock.app.block_info(),
+            EventData::DcaVaultCreated {},
+        )
+        .build(3)],
     );
 
     assert_vault_balance(
@@ -752,11 +762,16 @@ fn with_immediate_time_trigger_should_publish_events() {
         &mock,
         vault_id,
         &[
-            EventBuilder::new(vault_id, mock.app.block_info(), EventData::DCAVaultCreated).build(1),
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultFundsDeposited {
+                EventData::DcaVaultCreated {},
+            )
+            .build(1),
+            EventBuilder::new(
+                vault_id,
+                mock.app.block_info(),
+                EventData::DcaVaultFundsDeposited {
                     amount: Coin::new(vault_deposit.into(), DENOM_UKUJI),
                 },
             )
@@ -764,7 +779,7 @@ fn with_immediate_time_trigger_should_publish_events() {
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionTriggered {
+                EventData::DcaVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
                     asset_price: Decimal256::from_str("1.0").unwrap(),
@@ -774,7 +789,7 @@ fn with_immediate_time_trigger_should_publish_events() {
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionCompleted {
+                EventData::DcaVaultExecutionCompleted {
                     sent: Coin::new(swap_amount.into(), DENOM_UKUJI),
                     received: Coin::new(swap_amount.into(), DENOM_UTEST),
                     fee: Coin::new(
@@ -1070,7 +1085,12 @@ fn with_time_trigger_should_publish_vault_created_event() {
     assert_events_published(
         &mock,
         vault_id,
-        &[EventBuilder::new(vault_id, mock.app.block_info(), EventData::DCAVaultCreated).build(1)],
+        &[EventBuilder::new(
+            vault_id,
+            mock.app.block_info(),
+            EventData::DcaVaultCreated {},
+        )
+        .build(1)],
     );
 }
 
@@ -1115,7 +1135,7 @@ fn with_time_trigger_should_publish_funds_deposited_event() {
         &[EventBuilder::new(
             vault_id,
             mock.app.block_info(),
-            EventData::DCAVaultFundsDeposited {
+            EventData::DcaVaultFundsDeposited {
                 amount: Coin::new(vault_deposit.into(), DENOM_UKUJI),
             },
         )

--- a/contracts/dca/src/tests/deposit_tests.rs
+++ b/contracts/dca/src/tests/deposit_tests.rs
@@ -134,7 +134,7 @@ fn should_create_event() {
         &[EventBuilder::new(
             vault_id,
             mock.app.block_info(),
-            base::events::event::EventData::DCAVaultFundsDeposited {
+            base::events::event::EventData::DcaVaultFundsDeposited {
                 amount: Coin::new(TEN.into(), DENOM_UKUJI),
             },
         )

--- a/contracts/dca/src/tests/execute_trigger_tests.rs
+++ b/contracts/dca/src/tests/execute_trigger_tests.rs
@@ -237,7 +237,7 @@ fn for_filled_fin_limit_order_trigger_should_publish_events() {
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionTriggered {
+                EventData::DcaVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
                     asset_price: Decimal256::from_str("1.0").unwrap(),
@@ -247,7 +247,7 @@ fn for_filled_fin_limit_order_trigger_should_publish_events() {
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionCompleted {
+                EventData::DcaVaultExecutionCompleted {
                     sent: Coin::new(swap_amount.into(), DENOM_UKUJI),
                     received: Coin::new(swap_amount.into(), DENOM_UTEST),
                     fee: Coin::new((swap_amount - swap_amount_after_fee).into(), DENOM_UTEST),
@@ -807,7 +807,7 @@ fn for_ready_time_trigger_should_create_events() {
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionTriggered {
+                EventData::DcaVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
                     asset_price: Decimal256::from_str("1.0").unwrap(),
@@ -817,7 +817,7 @@ fn for_ready_time_trigger_should_create_events() {
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionCompleted {
+                EventData::DcaVaultExecutionCompleted {
                     sent: Coin::new(swap_amount.into(), DENOM_UKUJI),
                     received: Coin::new(swap_amount.into(), DENOM_UTEST),
                     fee: Coin::new((swap_amount - swap_amount_after_fee).into(), DENOM_UTEST),
@@ -1024,7 +1024,7 @@ fn for_ready_time_trigger_within_price_threshold_should_succeed() {
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionTriggered {
+                EventData::DcaVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
                     asset_price: Decimal256::from_str("1.0").unwrap(),
@@ -1034,7 +1034,7 @@ fn for_ready_time_trigger_within_price_threshold_should_succeed() {
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionCompleted {
+                EventData::DcaVaultExecutionCompleted {
                     sent: Coin::new(swap_amount.into(), DENOM_UKUJI),
                     received: Coin::new(swap_amount.into(), DENOM_UTEST),
                     fee: Coin::new((swap_amount - swap_amount_after_fee).into(), DENOM_UTEST),
@@ -1117,7 +1117,7 @@ fn for_ready_time_trigger_for_fin_buy_less_than_minimum_receive_amount_should_sk
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionTriggered {
+                EventData::DcaVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
                     asset_price: Decimal256::from_str("1.0").unwrap(),
@@ -1127,7 +1127,7 @@ fn for_ready_time_trigger_for_fin_buy_less_than_minimum_receive_amount_should_sk
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionSkipped {
+                EventData::DcaVaultExecutionSkipped {
                     reason: base::events::event::ExecutionSkippedReason::PriceThresholdExceeded {
                         price: Decimal256::from_str("1.0").unwrap(),
                     },
@@ -1186,7 +1186,7 @@ fn for_ready_time_trigger_for_fin_sell_less_than_minimum_receive_amount_should_s
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionTriggered {
+                EventData::DcaVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
                     asset_price: Decimal256::from_str("1.0").unwrap(),
@@ -1196,7 +1196,7 @@ fn for_ready_time_trigger_for_fin_sell_less_than_minimum_receive_amount_should_s
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionSkipped {
+                EventData::DcaVaultExecutionSkipped {
                     reason: base::events::event::ExecutionSkippedReason::PriceThresholdExceeded {
                         price: Decimal256::from_str("1.0").unwrap(),
                     },
@@ -1816,7 +1816,7 @@ fn until_vault_is_empty_should_create_events() {
             EventBuilder::new(
                 vault_id,
                 initial_block_info.clone(),
-                EventData::DCAVaultExecutionTriggered {
+                EventData::DcaVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
                     asset_price: Decimal256::from_str("1.0").unwrap(),
@@ -1826,7 +1826,7 @@ fn until_vault_is_empty_should_create_events() {
             EventBuilder::new(
                 vault_id,
                 initial_block_info.clone(),
-                EventData::DCAVaultExecutionCompleted {
+                EventData::DcaVaultExecutionCompleted {
                     sent: Coin::new(swap_amount.into(), DENOM_UKUJI),
                     received: Coin::new(swap_amount.into(), DENOM_UTEST),
                     fee: Coin::new((swap_amount - swap_amount_after_fee).into(), DENOM_UTEST),
@@ -1836,7 +1836,7 @@ fn until_vault_is_empty_should_create_events() {
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionTriggered {
+                EventData::DcaVaultExecutionTriggered {
                     base_denom: DENOM_UTEST.to_string(),
                     quote_denom: DENOM_UKUJI.to_string(),
                     asset_price: Decimal256::from_str("1.0").unwrap(),
@@ -1846,7 +1846,7 @@ fn until_vault_is_empty_should_create_events() {
             EventBuilder::new(
                 vault_id,
                 mock.app.block_info(),
-                EventData::DCAVaultExecutionCompleted {
+                EventData::DcaVaultExecutionCompleted {
                     sent: Coin::new(remaining_swap_amount.into(), DENOM_UKUJI),
                     received: Coin::new(remaining_swap_amount.into(), DENOM_UTEST),
                     fee: Coin::new(

--- a/contracts/dca/src/tests/get_events_by_resource_id_tests.rs
+++ b/contracts/dca/src/tests/get_events_by_resource_id_tests.rs
@@ -39,7 +39,7 @@ fn with_one_event_should_return_event() {
 
     create_event(
         &mut deps.storage,
-        EventBuilder::new(vault_id, env.block.clone(), EventData::DCAVaultCreated),
+        EventBuilder::new(vault_id, env.block.clone(), EventData::DcaVaultCreated {}),
     )
     .unwrap();
 
@@ -51,7 +51,7 @@ fn with_one_event_should_return_event() {
             resource_id: vault_id,
             timestamp: env.block.time,
             block_height: env.block.height,
-            data: EventData::DCAVaultCreated,
+            data: EventData::DcaVaultCreated {},
         }],
         None,
         None,
@@ -71,8 +71,8 @@ fn with_events_for_different_resources_should_return_one_event() {
     create_events(
         &mut deps.storage,
         vec![
-            EventBuilder::new(vault_id_1, env.block.clone(), EventData::DCAVaultCreated),
-            EventBuilder::new(vault_id_2, env.block.clone(), EventData::DCAVaultCreated),
+            EventBuilder::new(vault_id_1, env.block.clone(), EventData::DcaVaultCreated {}),
+            EventBuilder::new(vault_id_2, env.block.clone(), EventData::DcaVaultCreated {}),
         ],
     )
     .unwrap();
@@ -85,7 +85,7 @@ fn with_events_for_different_resources_should_return_one_event() {
             resource_id: vault_id_1,
             timestamp: env.block.time,
             block_height: env.block.height,
-            data: EventData::DCAVaultCreated,
+            data: EventData::DcaVaultCreated {},
         }],
         None,
         None,
@@ -104,11 +104,11 @@ fn with_two_events_should_return_events() {
     create_events(
         &mut deps.storage,
         vec![
-            EventBuilder::new(vault_id, env.block.clone(), EventData::DCAVaultCreated),
+            EventBuilder::new(vault_id, env.block.clone(), EventData::DcaVaultCreated {}),
             EventBuilder::new(
                 vault_id,
                 env.block.clone(),
-                EventData::DCAVaultFundsDeposited {
+                EventData::DcaVaultFundsDeposited {
                     amount: Coin::new(100, "ukuji".to_string()),
                 },
             ),
@@ -125,14 +125,14 @@ fn with_two_events_should_return_events() {
                 resource_id: vault_id,
                 timestamp: env.block.time,
                 block_height: env.block.height,
-                data: EventData::DCAVaultCreated,
+                data: EventData::DcaVaultCreated {},
             },
             Event {
                 id: 2,
                 resource_id: vault_id,
                 timestamp: env.block.time,
                 block_height: env.block.height,
-                data: EventData::DCAVaultFundsDeposited {
+                data: EventData::DcaVaultFundsDeposited {
                     amount: Coin::new(100, "ukuji".to_string()),
                 },
             },
@@ -154,11 +154,11 @@ fn with_start_after_should_return_later_events() {
     create_events(
         &mut deps.storage,
         vec![
-            EventBuilder::new(vault_id, env.block.clone(), EventData::DCAVaultCreated),
+            EventBuilder::new(vault_id, env.block.clone(), EventData::DcaVaultCreated {}),
             EventBuilder::new(
                 vault_id,
                 env.block.clone(),
-                EventData::DCAVaultFundsDeposited {
+                EventData::DcaVaultFundsDeposited {
                     amount: Coin::new(100, "ukuji".to_string()),
                 },
             ),
@@ -174,7 +174,7 @@ fn with_start_after_should_return_later_events() {
             resource_id: vault_id,
             timestamp: env.block.time,
             block_height: env.block.height,
-            data: EventData::DCAVaultFundsDeposited {
+            data: EventData::DcaVaultFundsDeposited {
                 amount: Coin::new(100, "ukuji".to_string()),
             },
         }],
@@ -195,11 +195,11 @@ fn with_limit_should_return_limited_events() {
     create_events(
         &mut deps.storage,
         vec![
-            EventBuilder::new(vault_id, env.block.clone(), EventData::DCAVaultCreated),
+            EventBuilder::new(vault_id, env.block.clone(), EventData::DcaVaultCreated {}),
             EventBuilder::new(
                 vault_id,
                 env.block.clone(),
-                EventData::DCAVaultFundsDeposited {
+                EventData::DcaVaultFundsDeposited {
                     amount: Coin::new(100, "ukuji".to_string()),
                 },
             ),
@@ -215,7 +215,7 @@ fn with_limit_should_return_limited_events() {
             resource_id: vault_id,
             timestamp: env.block.time,
             block_height: env.block.height,
-            data: EventData::DCAVaultCreated,
+            data: EventData::DcaVaultCreated {},
         }],
         None,
         Some(1),
@@ -234,15 +234,15 @@ fn with_start_after_and_limit_should_return_limited_later_events() {
     create_events(
         &mut deps.storage,
         vec![
-            EventBuilder::new(vault_id, env.block.clone(), EventData::DCAVaultCreated),
+            EventBuilder::new(vault_id, env.block.clone(), EventData::DcaVaultCreated {}),
             EventBuilder::new(
                 vault_id,
                 env.block.clone(),
-                EventData::DCAVaultFundsDeposited {
+                EventData::DcaVaultFundsDeposited {
                     amount: Coin::new(100, "ukuji".to_string()),
                 },
             ),
-            EventBuilder::new(vault_id, env.block.clone(), EventData::DCAVaultCancelled),
+            EventBuilder::new(vault_id, env.block.clone(), EventData::DcaVaultCancelled),
         ],
     )
     .unwrap();
@@ -255,7 +255,7 @@ fn with_start_after_and_limit_should_return_limited_later_events() {
             resource_id: vault_id,
             timestamp: env.block.time,
             block_height: env.block.height,
-            data: EventData::DCAVaultFundsDeposited {
+            data: EventData::DcaVaultFundsDeposited {
                 amount: Coin::new(100, "ukuji".to_string()),
             },
         }],

--- a/packages/base/src/events/event.rs
+++ b/packages/base/src/events/event.rs
@@ -10,25 +10,25 @@ pub enum ExecutionSkippedReason {
 
 #[cw_serde]
 pub enum EventData {
-    DCAVaultCreated,
-    DCAVaultFundsDeposited {
+    DcaVaultCreated {},
+    DcaVaultFundsDeposited {
         amount: Coin,
     },
-    DCAVaultExecutionTriggered {
+    DcaVaultExecutionTriggered {
         base_denom: String,
         quote_denom: String,
         asset_price: Decimal256,
     },
-    DCAVaultExecutionCompleted {
+    DcaVaultExecutionCompleted {
         sent: Coin,
         received: Coin,
         fee: Coin,
     },
-    DCAVaultExecutionSkipped {
+    DcaVaultExecutionSkipped {
         reason: ExecutionSkippedReason,
     },
-    DCAVaultCancelled,
-    DCAVaultZDelegationSucceeded {
+    DcaVaultCancelled,
+    DcaVaultZDelegationSucceeded {
         validator_address: String,
         delegation: Coin,
     },

--- a/packages/base/src/triggers/trigger.rs
+++ b/packages/base/src/triggers/trigger.rs
@@ -19,7 +19,7 @@ pub enum TriggerConfiguration {
     Time {
         target_time: Timestamp,
     },
-    FINLimitOrder {
+    FinLimitOrder {
         target_price: Decimal256,
         order_idx: Option<Uint128>,
     },


### PR DESCRIPTION
@aidan-calculated renamed DCA to Dca and FIN to Fin, and added empty object bodies to empty enum values