### PR TITLE
check for insufficient funds

### DIFF
--- a/contracts/dca/src/tests/after_fin_swap_tests.rs
+++ b/contracts/dca/src/tests/after_fin_swap_tests.rs
@@ -183,59 +183,6 @@ fn with_successful_swap_creates_a_new_time_trigger() {
 }
 
 #[test]
-fn with_insufficient_funds_publishes_unknown_failure_event() {
-    let mut deps = mock_dependencies();
-    let env = mock_env();
-    instantiate_contract(deps.as_mut(), env.clone(), mock_info(ADMIN, &vec![]));
-
-    setup_active_vault_with_low_funds(deps.as_mut(), env.clone());
-
-    let reply = Reply {
-        id: AFTER_FIN_SWAP_REPLY_ID,
-        result: SubMsgResult::Err("Generic failure".to_string()),
-    };
-
-    after_fin_swap(deps.as_mut(), env.clone(), reply).unwrap();
-
-    let vault_id = Uint128::one();
-
-    let events = get_events_by_resource_id(deps.as_ref(), vault_id, None, None)
-        .unwrap()
-        .events;
-
-    assert!(events.contains(
-        &EventBuilder::new(
-            vault_id,
-            env.block.clone(),
-            EventData::DcaVaultExecutionSkipped {
-                reason: ExecutionSkippedReason::UnknownFailure
-            }
-        )
-        .build(1)
-    ));
-}
-
-#[test]
-fn with_insufficient_funds_makes_vault_inactive() {
-    let mut deps = mock_dependencies();
-    let env = mock_env();
-    instantiate_contract(deps.as_mut(), env.clone(), mock_info(ADMIN, &vec![]));
-    setup_active_vault_with_low_funds(deps.as_mut(), env.clone());
-    let vault_id = Uint128::one();
-
-    let reply = Reply {
-        id: AFTER_FIN_SWAP_REPLY_ID,
-        result: SubMsgResult::Err("Generic failure".to_string()),
-    };
-
-    after_fin_swap(deps.as_mut(), env.clone(), reply).unwrap();
-
-    let vault = get_vault(&mut deps.storage, vault_id).unwrap();
-
-    assert_eq!(vault.status, VaultStatus::Inactive);
-}
-
-#[test]
 fn with_insufficient_funds_does_not_reduce_vault_balance() {
     let mut deps = mock_dependencies();
     let env = mock_env();

--- a/contracts/dca/src/tests/execute_trigger_tests.rs
+++ b/contracts/dca/src/tests/execute_trigger_tests.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use super::mocks::fin_contract_fail_slippage_tolerance;
+use super::mocks::{fin_contract_fail_slippage_tolerance, fin_contract_high_swap_price};
 use crate::constants::{ONE, ONE_HUNDRED, ONE_THOUSAND, TEN};
 use crate::msg::{ExecuteMsg, QueryMsg, TriggerIdsResponse, VaultResponse};
 use crate::tests::helpers::{
@@ -11,7 +11,7 @@ use crate::tests::mocks::{
     fin_contract_pass_slippage_tolerance, fin_contract_unfilled_limit_order, MockApp, ADMIN,
     DENOM_UKUJI, DENOM_UTEST, USER,
 };
-use base::events::event::{EventBuilder, EventData};
+use base::events::event::{EventBuilder, EventData, ExecutionSkippedReason};
 use base::helpers::math_helpers::checked_mul;
 use base::vaults::vault::{Destination, PostExecutionAction, VaultStatus};
 use cosmwasm_std::{Addr, Coin, Decimal, Decimal256, Uint128};
@@ -1919,4 +1919,201 @@ fn when_contract_is_paused_should_fail() {
         "Error: contract is paused",
         response.root_cause().to_string()
     )
+}
+
+#[test]
+fn for_vault_with_insufficient_swap_amount_should_set_vault_status_to_inactive() {
+    let user_address = Addr::unchecked(USER);
+    let user_balance = ONE;
+    let vault_deposit = ONE;
+    let swap_amount = Uint128::one();
+
+    let mut mock = MockApp::new(fin_contract_high_swap_price())
+        .with_funds_for(&user_address, user_balance, DENOM_UKUJI)
+        .with_vault_with_time_trigger(
+            &user_address,
+            None,
+            Coin::new(vault_deposit.into(), DENOM_UKUJI),
+            swap_amount,
+            "time",
+            None,
+        );
+
+    let vault_id = mock.vault_ids.get("time").unwrap().to_owned();
+
+    mock.elapse_time(10);
+
+    mock.app
+        .execute_contract(
+            Addr::unchecked(ADMIN),
+            mock.dca_contract_address.clone(),
+            &ExecuteMsg::ExecuteTrigger {
+                trigger_id: Uint128::new(1),
+            },
+            &[],
+        )
+        .unwrap();
+
+    let vault_response: VaultResponse = mock
+        .app
+        .wrap()
+        .query_wasm_smart(
+            &mock.dca_contract_address,
+            &&QueryMsg::GetVault { vault_id },
+        )
+        .unwrap();
+
+    assert_eq!(vault_response.vault.status, VaultStatus::Inactive);
+}
+
+#[test]
+fn for_vault_with_insufficient_swap_amount_should_not_update_vault_balance() {
+    let user_address = Addr::unchecked(USER);
+    let user_balance = ONE;
+    let vault_deposit = ONE;
+    let swap_amount = Uint128::one();
+
+    let mut mock = MockApp::new(fin_contract_high_swap_price())
+        .with_funds_for(&user_address, user_balance, DENOM_UKUJI)
+        .with_vault_with_time_trigger(
+            &user_address,
+            None,
+            Coin::new(vault_deposit.into(), DENOM_UKUJI),
+            swap_amount,
+            "time",
+            None,
+        );
+
+    let vault_id = mock.vault_ids.get("time").unwrap().to_owned();
+
+    mock.elapse_time(10);
+
+    mock.app
+        .execute_contract(
+            Addr::unchecked(ADMIN),
+            mock.dca_contract_address.clone(),
+            &ExecuteMsg::ExecuteTrigger {
+                trigger_id: Uint128::new(1),
+            },
+            &[],
+        )
+        .unwrap();
+
+    let vault_response: VaultResponse = mock
+        .app
+        .wrap()
+        .query_wasm_smart(
+            &mock.dca_contract_address,
+            &&QueryMsg::GetVault { vault_id },
+        )
+        .unwrap();
+
+    assert_eq!(vault_response.vault.balance.amount, vault_deposit);
+}
+
+#[test]
+fn for_vault_with_insufficient_swap_amount_should_not_update_address_balances() {
+    let user_address = Addr::unchecked(USER);
+    let user_balance = ONE;
+    let vault_deposit = ONE;
+    let swap_amount = Uint128::one();
+
+    let mut mock = MockApp::new(fin_contract_high_swap_price())
+        .with_funds_for(&user_address, user_balance, DENOM_UKUJI)
+        .with_vault_with_time_trigger(
+            &user_address,
+            None,
+            Coin::new(vault_deposit.into(), DENOM_UKUJI),
+            swap_amount,
+            "time",
+            None,
+        );
+
+    mock.elapse_time(10);
+
+    mock.app
+        .execute_contract(
+            Addr::unchecked(ADMIN),
+            mock.dca_contract_address.clone(),
+            &ExecuteMsg::ExecuteTrigger {
+                trigger_id: Uint128::new(1),
+            },
+            &[],
+        )
+        .unwrap();
+
+    assert_address_balances(
+        &mock,
+        &[
+            (&user_address, DENOM_UKUJI, Uint128::new(0)),
+            (&user_address, DENOM_UTEST, Uint128::new(0)),
+            (
+                &mock.dca_contract_address,
+                DENOM_UKUJI,
+                ONE_THOUSAND + vault_deposit,
+            ),
+            (&mock.dca_contract_address, DENOM_UTEST, ONE_THOUSAND),
+            (&mock.fin_contract_address, DENOM_UKUJI, ONE_THOUSAND),
+            (&mock.fin_contract_address, DENOM_UTEST, ONE_THOUSAND),
+        ],
+    );
+}
+
+#[test]
+fn for_vault_with_insufficient_swap_amount_should_publish_events() {
+    let user_address = Addr::unchecked(USER);
+    let user_balance = ONE;
+    let vault_deposit = ONE;
+    let swap_amount = Uint128::one();
+
+    let mut mock = MockApp::new(fin_contract_high_swap_price())
+        .with_funds_for(&user_address, user_balance, DENOM_UKUJI)
+        .with_vault_with_time_trigger(
+            &user_address,
+            None,
+            Coin::new(vault_deposit.into(), DENOM_UKUJI),
+            swap_amount,
+            "time",
+            None,
+        );
+
+    let vault_id = mock.vault_ids.get("time").unwrap().to_owned();
+
+    mock.elapse_time(10);
+
+    mock.app
+        .execute_contract(
+            Addr::unchecked(ADMIN),
+            mock.dca_contract_address.clone(),
+            &ExecuteMsg::ExecuteTrigger {
+                trigger_id: Uint128::new(1),
+            },
+            &[],
+        )
+        .unwrap();
+
+    assert_events_published(
+        &mock,
+        vault_id,
+        &[
+            EventBuilder::new(
+                vault_id,
+                mock.app.block_info(),
+                EventData::DcaVaultExecutionTriggered {
+                    base_denom: DENOM_UTEST.to_string(),
+                    quote_denom: DENOM_UKUJI.to_string(),
+                    asset_price: Decimal256::from_str("9").unwrap(),
+                },
+            )
+            .build(3),
+            EventBuilder::new(
+                vault_id,
+                mock.app.block_info(),
+                EventData::DcaVaultExecutionSkipped {
+                    reason: ExecutionSkippedReason::UnknownFailure,
+                },
+            )
+            .build(4),
+        ],
+    );
 }

--- a/contracts/dca/src/tests/mocks.rs
+++ b/contracts/dca/src/tests/mocks.rs
@@ -787,3 +787,26 @@ pub fn fin_contract_fail_slippage_tolerance() -> Box<dyn Contract<Empty>> {
     );
     Box::new(contract)
 }
+
+pub fn fin_contract_high_swap_price() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new(
+        |_, _, info, msg: FINExecuteMsg| -> StdResult<Response> {
+            match msg {
+                FINExecuteMsg::Swap { .. } => default_swap_handler(info),
+                _ => Ok(Response::default()),
+            }
+        },
+        |_, _, _, _: FINInstantiateMsg| -> StdResult<Response> { Ok(Response::new()) },
+        |_, _, msg: FINQueryMsg| -> StdResult<Binary> {
+            match msg {
+                FINQueryMsg::Book { .. } => book_response_handler(
+                    String::from(DENOM_UTEST),
+                    Decimal256::from_str("9")?,
+                    Decimal256::from_str("11")?,
+                ),
+                _ => default_query_response(),
+            }
+        },
+    );
+    Box::new(contract)
+}

--- a/contracts/dca/src/types/vault.rs
+++ b/contracts/dca/src/types/vault.rs
@@ -6,6 +6,7 @@ use base::{
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Coin, Decimal256, Timestamp, Uint128};
 use kujira::precision::{Precise, Precision};
+use std::cmp::min;
 
 #[cw_serde]
 pub struct Vault {
@@ -67,11 +68,14 @@ impl Vault {
 
     pub fn price_threshold_exceeded(&self, price: Decimal256) -> bool {
         if let Some(minimum_receive_amount) = self.minimum_receive_amount {
+            let target_swap_amount_as_decimal =
+                Decimal256::from_ratio(self.swap_amount, Uint128::one());
+
             let receive_amount_at_price = match self.get_position_type() {
-                PositionType::Enter => Decimal256::from_ratio(self.swap_amount, Uint128::one())
+                PositionType::Enter => target_swap_amount_as_decimal
                     .checked_div(price)
                     .expect("current fin price should be > 0.0"),
-                PositionType::Exit => Decimal256::from_ratio(self.swap_amount, Uint128::one())
+                PositionType::Exit => target_swap_amount_as_decimal
                     .checked_mul(price)
                     .expect("expected receive amount should be valid"),
             };
@@ -83,6 +87,22 @@ impl Vault {
         }
 
         false
+    }
+
+    pub fn has_sufficient_funds(&self, fin_price: Decimal256) -> bool {
+        let swap_amount_as_decimal =
+            Decimal256::from_ratio(self.get_swap_amount().amount, Uint128::one());
+
+        let minimum_possible_receive_amount = min(
+            swap_amount_as_decimal
+                .checked_mul(fin_price)
+                .expect("minimum possible receive amount should be valid"),
+            swap_amount_as_decimal
+                .checked_div(fin_price)
+                .expect("minimum possible receive amount should be valid"),
+        );
+
+        minimum_possible_receive_amount >= Decimal256::one()
     }
 
     pub fn low_funds(&self) -> bool {
@@ -99,6 +119,68 @@ impl Vault {
 
     pub fn is_scheduled(&self) -> bool {
         self.status == VaultStatus::Scheduled
+    }
+}
+
+#[cfg(test)]
+mod has_sufficient_funds_tests {
+    use super::*;
+    use cosmwasm_std::coin;
+    use std::str::FromStr;
+
+    #[test]
+    fn should_return_false_when_vault_has_insufficient_swap_amount_with_inverted_fin_price() {
+        let vault = vault_with(Uint128::new(1));
+        assert!(!vault.has_sufficient_funds(Decimal256::from_str("0.99").unwrap()));
+    }
+
+    #[test]
+    fn should_return_true_when_vault_has_just_enough_swap_amount() {
+        let vault = vault_with(Uint128::new(1));
+        assert!(vault.has_sufficient_funds(Decimal256::from_str("1.0").unwrap()));
+    }
+
+    #[test]
+    fn should_return_false_when_vault_has_insufficient_swap_amount_with_fin_price() {
+        let vault = vault_with(Uint128::new(1));
+        assert!(!vault.has_sufficient_funds(Decimal256::from_str("1.01").unwrap()));
+    }
+
+    #[test]
+    fn should_return_true_when_vault_has_sufficient_swap_amount_with_inverted_fin_price() {
+        let vault = vault_with(Uint128::new(2));
+        assert!(vault.has_sufficient_funds(Decimal256::from_str("0.99").unwrap()));
+    }
+
+    #[test]
+    fn should_return_true_when_vault_has_sufficient_swap_amount_with_fin_price() {
+        let vault = vault_with(Uint128::new(2));
+        assert!(vault.has_sufficient_funds(Decimal256::from_str("1.01").unwrap()));
+    }
+
+    fn vault_with(swap_amount: Uint128) -> Vault {
+        Vault {
+            id: Uint128::new(1),
+            created_at: Timestamp::from_seconds(0),
+            owner: Addr::unchecked("owner"),
+            label: None,
+            destinations: vec![],
+            status: VaultStatus::Active,
+            balance: coin(1000, "quote"),
+            pair: Pair {
+                address: Addr::unchecked("pair"),
+                base_denom: "base".to_string(),
+                quote_denom: "quote".to_string(),
+            },
+            swap_amount,
+            slippage_tolerance: None,
+            minimum_receive_amount: None,
+            time_interval: TimeInterval::Daily,
+            started_at: None,
+            swapped_amount: coin(0, "quote"),
+            received_amount: coin(0, "base"),
+            trigger: None,
+        }
     }
 }
 


### PR DESCRIPTION
Changes include:
* Checking if the swap amount is enough before swapping, and making vault inactive if not
  - check if both `swap_amount * fin_price` and `swap_amount / fin_price` are > 0
  - if not true, then fail
* Always setting execute failure reason to slippage exceeded after fin swap failures 