### PR TITLE
calculate total fees before doing delegations

### DIFF
--- a/contracts/dca/src/handlers/after_fin_swap.rs
+++ b/contracts/dca/src/handlers/after_fin_swap.rs
@@ -93,15 +93,25 @@ pub fn after_fin_swap(deps: DepsMut, env: Env, reply: Reply) -> Result<Response,
             let swap_fee = checked_mul(coin_received.amount, fee_percent)?;
             let total_after_swap_fee = coin_received.amount - swap_fee;
             let automation_fee = checked_mul(total_after_swap_fee, automation_fee_rate)?;
-            let total_fee = swap_fee + automation_fee;
 
-            if total_fee.gt(&Uint128::zero()) {
+            if swap_fee.gt(&Uint128::zero()) {
                 messages.push(CosmosMsg::Bank(BankMsg::Send {
                     to_address: config.fee_collector.to_string(),
-                    amount: vec![Coin::new(total_fee.into(), coin_received.denom.clone())],
+                    amount: vec![Coin::new(swap_fee.into(), coin_received.denom.clone())],
                 }));
             }
 
+            if automation_fee.gt(&Uint128::zero()) {
+                messages.push(CosmosMsg::Bank(BankMsg::Send {
+                    to_address: config.fee_collector.to_string(),
+                    amount: vec![Coin::new(
+                        automation_fee.into(),
+                        coin_received.denom.clone(),
+                    )],
+                }));
+            }
+
+            let total_fee = swap_fee + automation_fee;
             let total_after_total_fee = coin_received.amount - total_fee;
 
             vault.destinations.iter().for_each(|destination| {

--- a/contracts/dca/src/tests/after_fin_swap_tests.rs
+++ b/contracts/dca/src/tests/after_fin_swap_tests.rs
@@ -95,7 +95,7 @@ fn with_succcesful_swap_returns_fee_to_fee_collector() {
     instantiate_contract(deps.as_mut(), env.clone(), mock_info(ADMIN, &vec![]));
 
     let vault = setup_active_vault_with_funds(deps.as_mut(), env.clone());
-    let receive_amount = Uint128::new(234312312);
+    let received_amount = Uint128::new(234312312);
 
     let response = after_fin_swap(
         deps.as_mut(),
@@ -105,7 +105,7 @@ fn with_succcesful_swap_returns_fee_to_fee_collector() {
             result: SubMsgResult::Ok(SubMsgResponse {
                 events: vec![Event::new("wasm-trade")
                     .add_attribute("base_amount", vault.get_swap_amount().amount.to_string())
-                    .add_attribute("quote_amount", receive_amount.to_string())],
+                    .add_attribute("quote_amount", received_amount.to_string())],
                 data: None,
             }),
         },
@@ -113,24 +113,29 @@ fn with_succcesful_swap_returns_fee_to_fee_collector() {
     .unwrap();
 
     let config = get_config(&deps.storage).unwrap();
+    let swap_fee = config.swap_fee_percent * received_amount;
+    let total_after_swap_fee = received_amount - swap_fee;
 
-    let mut fee = config.swap_fee_percent * receive_amount;
-
-    vault
+    let automation_fee = vault
         .destinations
         .iter()
         .filter(|d| d.action == PostExecutionAction::ZDelegate)
-        .for_each(|destination| {
+        .fold(Uint128::zero(), |acc, destination| {
             let allocation_amount =
-                checked_mul(receive_amount - fee, destination.allocation).unwrap();
+                checked_mul(total_after_swap_fee, destination.allocation).unwrap();
             let allocation_automation_fee =
                 checked_mul(allocation_amount, config.delegation_fee_percent).unwrap();
-            fee = fee.checked_add(allocation_automation_fee).unwrap();
+            acc.checked_add(allocation_automation_fee).unwrap()
         });
 
     assert!(response.messages.contains(&SubMsg::new(BankMsg::Send {
         to_address: config.fee_collector.to_string(),
-        amount: vec![Coin::new(fee.into(), vault.get_receive_denom())]
+        amount: vec![Coin::new(swap_fee.into(), vault.get_receive_denom())]
+    })));
+
+    assert!(response.messages.contains(&SubMsg::new(BankMsg::Send {
+        to_address: config.fee_collector.to_string(),
+        amount: vec![Coin::new(automation_fee.into(), vault.get_receive_denom())]
     })));
 }
 
@@ -509,7 +514,7 @@ fn with_custom_fee_for_base_denom_takes_custom_fee() {
     )
     .unwrap();
 
-    let receive_amount = Uint128::new(234312312);
+    let received_amount = Uint128::new(234312312);
 
     let response = after_fin_swap(
         deps.as_mut(),
@@ -519,7 +524,7 @@ fn with_custom_fee_for_base_denom_takes_custom_fee() {
             result: SubMsgResult::Ok(SubMsgResponse {
                 events: vec![Event::new("wasm-trade")
                     .add_attribute("base_amount", vault.get_swap_amount().amount.to_string())
-                    .add_attribute("quote_amount", receive_amount.to_string())],
+                    .add_attribute("quote_amount", received_amount.to_string())],
                 data: None,
             }),
         },
@@ -527,23 +532,29 @@ fn with_custom_fee_for_base_denom_takes_custom_fee() {
     .unwrap();
 
     let config = get_config(&deps.storage).unwrap();
-    let mut fee = custom_fee_percent * receive_amount;
+    let swap_fee = custom_fee_percent * received_amount;
+    let total_after_swap_fee = received_amount - swap_fee;
 
-    vault
+    let automation_fee = vault
         .destinations
         .iter()
         .filter(|d| d.action == PostExecutionAction::ZDelegate)
-        .for_each(|destination| {
+        .fold(Uint128::zero(), |acc, destination| {
             let allocation_amount =
-                checked_mul(receive_amount - fee, destination.allocation).unwrap();
+                checked_mul(total_after_swap_fee, destination.allocation).unwrap();
             let allocation_automation_fee =
                 checked_mul(allocation_amount, config.delegation_fee_percent).unwrap();
-            fee = fee.checked_add(allocation_automation_fee).unwrap();
+            acc.checked_add(allocation_automation_fee).unwrap()
         });
 
     assert!(response.messages.contains(&SubMsg::new(BankMsg::Send {
         to_address: config.fee_collector.to_string(),
-        amount: vec![Coin::new(fee.into(), vault.get_receive_denom())]
+        amount: vec![Coin::new(swap_fee.into(), vault.get_receive_denom())]
+    })));
+
+    assert!(response.messages.contains(&SubMsg::new(BankMsg::Send {
+        to_address: config.fee_collector.to_string(),
+        amount: vec![Coin::new(automation_fee.into(), vault.get_receive_denom())]
     })));
 }
 
@@ -564,7 +575,7 @@ fn with_custom_fee_for_quote_denom_takes_custom_fee() {
     )
     .unwrap();
 
-    let receive_amount = Uint128::new(234312312);
+    let received_amount = Uint128::new(234312312);
 
     let response = after_fin_swap(
         deps.as_mut(),
@@ -574,7 +585,7 @@ fn with_custom_fee_for_quote_denom_takes_custom_fee() {
             result: SubMsgResult::Ok(SubMsgResponse {
                 events: vec![Event::new("wasm-trade")
                     .add_attribute("base_amount", vault.get_swap_amount().amount.to_string())
-                    .add_attribute("quote_amount", receive_amount.to_string())],
+                    .add_attribute("quote_amount", received_amount.to_string())],
                 data: None,
             }),
         },
@@ -582,23 +593,29 @@ fn with_custom_fee_for_quote_denom_takes_custom_fee() {
     .unwrap();
 
     let config = get_config(&deps.storage).unwrap();
-    let mut fee = custom_fee_percent * receive_amount;
+    let swap_fee = custom_fee_percent * received_amount;
+    let total_after_swap_fee = received_amount - swap_fee;
 
-    vault
+    let automation_fee = vault
         .destinations
         .iter()
         .filter(|d| d.action == PostExecutionAction::ZDelegate)
-        .for_each(|destination| {
+        .fold(Uint128::zero(), |acc, destination| {
             let allocation_amount =
-                checked_mul(receive_amount - fee, destination.allocation).unwrap();
+                checked_mul(total_after_swap_fee, destination.allocation).unwrap();
             let allocation_automation_fee =
                 checked_mul(allocation_amount, config.delegation_fee_percent).unwrap();
-            fee = fee.checked_add(allocation_automation_fee).unwrap();
+            acc.checked_add(allocation_automation_fee).unwrap()
         });
 
     assert!(response.messages.contains(&SubMsg::new(BankMsg::Send {
         to_address: config.fee_collector.to_string(),
-        amount: vec![Coin::new(fee.into(), vault.get_receive_denom())]
+        amount: vec![Coin::new(swap_fee.into(), vault.get_receive_denom())]
+    })));
+
+    assert!(response.messages.contains(&SubMsg::new(BankMsg::Send {
+        to_address: config.fee_collector.to_string(),
+        amount: vec![Coin::new(automation_fee.into(), vault.get_receive_denom())]
     })));
 }
 
@@ -627,7 +644,7 @@ fn with_custom_fee_for_both_denoms_takes_lower_fee() {
     )
     .unwrap();
 
-    let receive_amount = Uint128::new(234312312);
+    let received_amount = Uint128::new(234312312);
 
     let response = after_fin_swap(
         deps.as_mut(),
@@ -637,7 +654,7 @@ fn with_custom_fee_for_both_denoms_takes_lower_fee() {
             result: SubMsgResult::Ok(SubMsgResponse {
                 events: vec![Event::new("wasm-trade")
                     .add_attribute("base_amount", vault.get_swap_amount().amount.to_string())
-                    .add_attribute("quote_amount", receive_amount.to_string())],
+                    .add_attribute("quote_amount", received_amount.to_string())],
                 data: None,
             }),
         },
@@ -645,22 +662,28 @@ fn with_custom_fee_for_both_denoms_takes_lower_fee() {
     .unwrap();
 
     let config = get_config(&deps.storage).unwrap();
-    let mut fee = min(swap_denom_fee_percent, receive_denom_fee_percent) * receive_amount;
+    let swap_fee = min(swap_denom_fee_percent, receive_denom_fee_percent) * received_amount;
+    let total_after_swap_fee = received_amount - swap_fee;
 
-    vault
+    let automation_fee = vault
         .destinations
         .iter()
         .filter(|d| d.action == PostExecutionAction::ZDelegate)
-        .for_each(|destination| {
+        .fold(Uint128::zero(), |acc, destination| {
             let allocation_amount =
-                checked_mul(receive_amount - fee, destination.allocation).unwrap();
+                checked_mul(total_after_swap_fee, destination.allocation).unwrap();
             let allocation_automation_fee =
                 checked_mul(allocation_amount, config.delegation_fee_percent).unwrap();
-            fee = fee.checked_add(allocation_automation_fee).unwrap();
+            acc.checked_add(allocation_automation_fee).unwrap()
         });
 
     assert!(response.messages.contains(&SubMsg::new(BankMsg::Send {
         to_address: config.fee_collector.to_string(),
-        amount: vec![Coin::new(fee.into(), vault.get_receive_denom())]
+        amount: vec![Coin::new(swap_fee.into(), vault.get_receive_denom())]
+    })));
+
+    assert!(response.messages.contains(&SubMsg::new(BankMsg::Send {
+        to_address: config.fee_collector.to_string(),
+        amount: vec![Coin::new(automation_fee.into(), vault.get_receive_denom())]
     })));
 }


### PR DESCRIPTION
@aidan-calculated refactor the fee taking logic to be safer to think about and code around

Changes include:
* working out the swap fee and automation fees at the start
* combining them and subtracting them from the total before doing the destination allocation logic
* using the combined fees for the bank msg to the fee collector, the execution completed event, and the vault stats