### PR TITLE
add separate destination binary store

### DIFF
--- a/contracts/dca/schema/dca.json
+++ b/contracts/dca/schema/dca.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dca",
-  "contract_version": "0.11.0",
+  "contract_version": "1.0.3",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -416,6 +416,29 @@
             "properties": {
               "denom": {
                 "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "migrate_event"
+        ],
+        "properties": {
+          "migrate_event": {
+            "type": "object",
+            "required": [
+              "limit"
+            ],
+            "properties": {
+              "limit": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
               }
             },
             "additionalProperties": false
@@ -1056,6 +1079,37 @@
                 }
               },
               "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "price_delta_limit_exceeded"
+              ],
+              "properties": {
+                "price_delta_limit_exceeded": {
+                  "type": "object",
+                  "required": [
+                    "actual_price_delta",
+                    "duration_in_seconds",
+                    "max_price_delta"
+                  ],
+                  "properties": {
+                    "actual_price_delta": {
+                      "$ref": "#/definitions/Decimal256"
+                    },
+                    "duration_in_seconds": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "max_price_delta": {
+                      "$ref": "#/definitions/Decimal256"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
             }
           ]
         },
@@ -1335,6 +1389,37 @@
                   ],
                   "properties": {
                     "price": {
+                      "$ref": "#/definitions/Decimal256"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "price_delta_limit_exceeded"
+              ],
+              "properties": {
+                "price_delta_limit_exceeded": {
+                  "type": "object",
+                  "required": [
+                    "actual_price_delta",
+                    "duration_in_seconds",
+                    "max_price_delta"
+                  ],
+                  "properties": {
+                    "actual_price_delta": {
+                      "$ref": "#/definitions/Decimal256"
+                    },
+                    "duration_in_seconds": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "max_price_delta": {
                       "$ref": "#/definitions/Decimal256"
                     }
                   },

--- a/contracts/dca/src/types/vault_builder.rs
+++ b/contracts/dca/src/types/vault_builder.rs
@@ -1,11 +1,10 @@
+use super::vault::Vault;
 use base::{
     pair::Pair,
     triggers::trigger::TimeInterval,
     vaults::vault::{Destination, PositionType, VaultStatus},
 };
 use cosmwasm_std::{coin, Addr, Coin, Decimal256, Timestamp, Uint128};
-
-use super::vault::Vault;
 
 pub struct VaultBuilder {
     pub created_at: Timestamp,

--- a/packages/base/src/vaults/vault.rs
+++ b/packages/base/src/vaults/vault.rs
@@ -16,9 +16,22 @@ pub enum VaultStatus {
 }
 
 #[cw_serde]
+pub enum PostExecutionActionDeprecated {
+    Send,
+    ZDelegate,
+}
+
+#[cw_serde]
 pub enum PostExecutionAction {
     Send,
     ZDelegate,
+}
+
+#[cw_serde]
+pub struct DestinationDeprecated {
+    pub address: Addr,
+    pub allocation: Decimal,
+    pub action: PostExecutionActionDeprecated,
 }
 
 #[cw_serde]


### PR DESCRIPTION
@aidan-calculated fingers crossed a rename of the struct doesn't break things.

If it does, we can go back to the old name and start using a new version  for the `DESTINATIONS` map, thoughts?