### PR TITLE
use `ContractResult` instead of `StdResult`

### DIFF
--- a/contracts/swap/src/handlers/add_path.rs
+++ b/contracts/swap/src/handlers/add_path.rs
@@ -1,7 +1,10 @@
-use crate::{state::paths::add_path, types::pair::Pair, validation::assert_sender_is_admin};
-use cosmwasm_std::{DepsMut, MessageInfo, Response, StdResult};
+use crate::{
+    contract::ContractResult, state::paths::add_path, types::pair::Pair,
+    validation::assert_sender_is_admin,
+};
+use cosmwasm_std::{DepsMut, MessageInfo, Response};
 
-pub fn add_path_handler(deps: DepsMut, info: MessageInfo, pair: Pair) -> StdResult<Response> {
+pub fn add_path_handler(deps: DepsMut, info: MessageInfo, pair: Pair) -> ContractResult<Response> {
     assert_sender_is_admin(deps.storage, info.sender)?;
     add_path(deps.storage, pair.clone())?;
     Ok(Response::new()

--- a/contracts/swap/src/handlers/continue_swap.rs
+++ b/contracts/swap/src/handlers/continue_swap.rs
@@ -1,14 +1,15 @@
 use crate::{
+    contract::ContractResult,
     state::swap_messages::{get_swap_messages, save_swap_messages},
     validation::assert_exactly_one_asset,
 };
-use cosmwasm_std::{CosmosMsg, DepsMut, MessageInfo, Response, StdResult, WasmMsg};
+use cosmwasm_std::{CosmosMsg, DepsMut, MessageInfo, Response, WasmMsg};
 
 pub fn continue_swap_handler(
     deps: DepsMut,
     info: MessageInfo,
     swap_id: u64,
-) -> StdResult<Response> {
+) -> ContractResult<Response> {
     assert_exactly_one_asset(&info.funds)?;
 
     let mut swap_messages = get_swap_messages(deps.storage, swap_id)?;

--- a/contracts/swap/src/handlers/create_swap.rs
+++ b/contracts/swap/src/handlers/create_swap.rs
@@ -1,4 +1,5 @@
 use crate::{
+    contract::ContractResult,
     msg::ExecuteMsg,
     shared::helpers::get_cheapest_swap_path,
     state::swap_messages::{get_next_swap_id, save_swap_messages},
@@ -19,7 +20,7 @@ pub fn create_swap_handler(
     target_denom: String,
     slippage_tolerance: Option<Decimal256>,
     on_complete: Option<Callback>,
-) -> StdResult<Response> {
+) -> ContractResult<Response> {
     assert_exactly_one_asset(&info.funds)?;
 
     let cheapest_swap_path = get_cheapest_swap_path(deps.as_ref(), &info.funds[0], &target_denom)?;
@@ -124,7 +125,7 @@ mod swap_tests {
 
         assert_eq!(
             response.unwrap_err().to_string(),
-            "Generic error: received 0 denoms but required exactly 1"
+            "Error: received 0 denoms but required exactly 1"
         )
     }
 

--- a/contracts/swap/src/handlers/send_funds.rs
+++ b/contracts/swap/src/handlers/send_funds.rs
@@ -1,6 +1,8 @@
-use cosmwasm_std::{Addr, BankMsg, CosmosMsg, MessageInfo, Response, StdResult};
+use cosmwasm_std::{Addr, BankMsg, CosmosMsg, MessageInfo, Response};
 
-pub fn send_funds_handler(info: MessageInfo, address: Addr) -> StdResult<Response> {
+use crate::contract::ContractResult;
+
+pub fn send_funds_handler(info: MessageInfo, address: Addr) -> ContractResult<Response> {
     Ok(Response::new().add_message(CosmosMsg::Bank(BankMsg::Send {
         to_address: address.to_string(),
         amount: info.funds,

--- a/contracts/swap/src/handlers/swap_on_fin.rs
+++ b/contracts/swap/src/handlers/swap_on_fin.rs
@@ -1,12 +1,12 @@
 use crate::{
-    contract::AFTER_FIN_SWAP_REPLY_ID,
+    contract::{ContractResult, AFTER_FIN_SWAP_REPLY_ID},
     state::cache::{SwapCache, SWAP_CACHE},
     types::callback::Callback,
     validation::{assert_exactly_one_asset, assert_sender_is_contract},
 };
 use base::pair::Pair;
 use cosmwasm_std::{
-    Binary, CosmosMsg, Decimal256, DepsMut, Env, MessageInfo, ReplyOn, Response, StdResult, WasmMsg,
+    Binary, CosmosMsg, Decimal256, DepsMut, Env, MessageInfo, ReplyOn, Response, WasmMsg,
 };
 use fin_helpers::swaps::create_fin_swap_message;
 
@@ -17,7 +17,7 @@ pub fn swap_on_fin_handler(
     pair: Pair,
     slippage_tolerance: Option<Decimal256>,
     callback: Binary,
-) -> StdResult<Response> {
+) -> ContractResult<Response> {
     assert_sender_is_contract(&info.sender, env)?;
     assert_exactly_one_asset(&info.funds)?;
 
@@ -52,7 +52,7 @@ pub fn swap_on_fin_handler(
     )?))
 }
 
-pub fn after_swap_on_fin_handler(deps: DepsMut, env: Env) -> StdResult<Response> {
+pub fn after_swap_on_fin_handler(deps: DepsMut, env: Env) -> ContractResult<Response> {
     let swap_cache = SWAP_CACHE.load(deps.storage)?;
 
     let receive_denom_balance = deps.querier.query_balance(

--- a/contracts/swap/src/handlers/update_config.rs
+++ b/contracts/swap/src/handlers/update_config.rs
@@ -1,14 +1,15 @@
 use crate::{
+    contract::ContractResult,
     state::config::{update_config, Config},
     validation::assert_sender_is_admin,
 };
-use cosmwasm_std::{DepsMut, MessageInfo, Response, StdResult};
+use cosmwasm_std::{DepsMut, MessageInfo, Response};
 
 pub fn update_config_handler(
     deps: DepsMut,
     info: MessageInfo,
     config: Config,
-) -> StdResult<Response> {
+) -> ContractResult<Response> {
     assert_sender_is_admin(deps.storage, info.sender)?;
     deps.api.addr_validate(&config.admin.to_string())?;
     update_config(deps.storage, config)?;

--- a/contracts/swap/src/validation.rs
+++ b/contracts/swap/src/validation.rs
@@ -1,29 +1,27 @@
-use crate::state::config::get_config;
-use cosmwasm_std::{Addr, Coin, Env, StdError, StdResult, Storage};
+use crate::{
+    contract::ContractResult, errors::contract_error::ContractError, state::config::get_config,
+};
+use cosmwasm_std::{Addr, Coin, Env, Storage};
 
-pub fn assert_sender_is_admin(storage: &mut dyn Storage, sender: Addr) -> StdResult<()> {
+pub fn assert_sender_is_admin(storage: &mut dyn Storage, sender: Addr) -> ContractResult<()> {
     let config = get_config(storage)?;
     if sender != config.admin {
-        return Err(StdError::GenericErr {
-            msg: "Unauthorised".to_string(),
-        });
+        return Err(ContractError::Unauthorized {});
     }
     Ok(())
 }
 
-pub fn assert_sender_is_contract(sender: &Addr, env: &Env) -> StdResult<()> {
+pub fn assert_sender_is_contract(sender: &Addr, env: &Env) -> ContractResult<()> {
     if sender != &env.contract.address {
-        return Err(StdError::GenericErr {
-            msg: "Unauthorised".to_string(),
-        });
+        return Err(ContractError::Unauthorized {});
     }
     Ok(())
 }
 
-pub fn assert_exactly_one_asset(funds: &Vec<Coin>) -> StdResult<()> {
+pub fn assert_exactly_one_asset(funds: &Vec<Coin>) -> ContractResult<()> {
     if funds.is_empty() || funds.len() > 1 {
-        return Err(StdError::GenericErr {
-            msg: format!("received {} denoms but required exactly 1", funds.len()),
+        return Err(ContractError::CustomError {
+            val: format!("received {} denoms but required exactly 1", funds.len()),
         });
     }
     Ok(())


### PR DESCRIPTION
Allow us to use ContractErrors with clean syntax 

@fluffydonkey 