### PR TITLE
add dca plus escrow level to config

### DIFF
--- a/contracts/dca/src/contract.rs
+++ b/contracts/dca/src/contract.rs
@@ -32,6 +32,7 @@ use crate::msg::{ConfigResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMs
 use crate::state::config::{get_config, update_config, Config};
 use crate::state::fin_limit_order_change_timestamp::FIN_LIMIT_ORDER_CHANGE_TIMESTAMP;
 use crate::validation_helpers::{
+    assert_dca_plus_escrow_level_is_less_than_100_percent,
     assert_fee_collector_addresses_are_valid, assert_fee_collector_allocations_add_up_to_one,
     assert_sender_is_admin,
 };
@@ -69,6 +70,7 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Result<Response, Con
 
     assert_fee_collector_addresses_are_valid(deps.as_ref(), &msg.fee_collectors)?;
     assert_fee_collector_allocations_add_up_to_one(&msg.fee_collectors)?;
+    assert_dca_plus_escrow_level_is_less_than_100_percent(msg.dca_plus_escrow_level)?;
 
     update_config(
         deps.storage,
@@ -80,6 +82,7 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Result<Response, Con
             staking_router_address: msg.staking_router_address,
             page_limit: msg.page_limit,
             paused: msg.paused,
+            dca_plus_escrow_level: msg.dca_plus_escrow_level,
         },
     )?;
 
@@ -101,6 +104,7 @@ pub fn instantiate(
 
     assert_fee_collector_addresses_are_valid(deps.as_ref(), &msg.fee_collectors)?;
     assert_fee_collector_allocations_add_up_to_one(&msg.fee_collectors)?;
+    assert_dca_plus_escrow_level_is_less_than_100_percent(msg.dca_plus_escrow_level)?;
 
     update_config(
         deps.storage,
@@ -112,6 +116,7 @@ pub fn instantiate(
             staking_router_address: msg.staking_router_address,
             page_limit: msg.page_limit,
             paused: msg.paused,
+            dca_plus_escrow_level: msg.dca_plus_escrow_level,
         },
     )?;
 
@@ -174,6 +179,7 @@ pub fn execute(
             staking_router_address,
             page_limit,
             paused,
+            dca_plus_escrow_level,
         } => update_config_handler(
             deps,
             info,
@@ -183,6 +189,7 @@ pub fn execute(
             staking_router_address,
             page_limit,
             paused,
+            dca_plus_escrow_level,
         ),
         ExecuteMsg::UpdateVault {
             address,

--- a/contracts/dca/src/handlers/update_config.rs
+++ b/contracts/dca/src/handlers/update_config.rs
@@ -2,6 +2,7 @@ use crate::{
     error::ContractError,
     state::config::{get_config, update_config, Config, FeeCollector},
     validation_helpers::{
+        assert_dca_plus_escrow_level_is_less_than_100_percent,
         assert_fee_collector_addresses_are_valid, assert_fee_collector_allocations_add_up_to_one,
         assert_sender_is_admin,
     },
@@ -17,6 +18,7 @@ pub fn update_config_handler(
     staking_router_address: Option<Addr>,
     page_limit: Option<u16>,
     paused: Option<bool>,
+    dca_plus_escrow_level: Option<Decimal>,
 ) -> Result<Response, ContractError> {
     assert_sender_is_admin(deps.storage, info.sender)?;
     let existing_config = get_config(deps.storage)?;
@@ -34,10 +36,13 @@ pub fn update_config_handler(
         )?,
         page_limit: page_limit.unwrap_or(existing_config.page_limit),
         paused: paused.unwrap_or(existing_config.paused),
+        dca_plus_escrow_level: dca_plus_escrow_level
+            .unwrap_or(existing_config.dca_plus_escrow_level),
     };
 
     assert_fee_collector_addresses_are_valid(deps.as_ref(), &config.fee_collectors)?;
     assert_fee_collector_allocations_add_up_to_one(&config.fee_collectors)?;
+    assert_dca_plus_escrow_level_is_less_than_100_percent(config.dca_plus_escrow_level)?;
 
     let config = update_config(deps.storage, config)?;
 

--- a/contracts/dca/src/msg.rs
+++ b/contracts/dca/src/msg.rs
@@ -19,6 +19,7 @@ pub struct InstantiateMsg {
     pub staking_router_address: Addr,
     pub page_limit: u16,
     pub paused: bool,
+    pub dca_plus_escrow_level: Decimal,
 }
 
 #[cw_serde]
@@ -30,6 +31,7 @@ pub struct MigrateMsg {
     pub staking_router_address: Addr,
     pub page_limit: u16,
     pub paused: bool,
+    pub dca_plus_escrow_level: Decimal,
 }
 
 #[cw_serde]
@@ -72,6 +74,7 @@ pub enum ExecuteMsg {
         staking_router_address: Option<Addr>,
         page_limit: Option<u16>,
         paused: Option<bool>,
+        dca_plus_escrow_level: Option<Decimal>,
     },
     UpdateVault {
         address: Addr,

--- a/contracts/dca/src/state/config.rs
+++ b/contracts/dca/src/state/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub staking_router_address: Addr,
     pub page_limit: u16,
     pub paused: bool,
+    pub dca_plus_escrow_level: Decimal,
 }
 
 #[cw_serde]

--- a/contracts/dca/src/tests/contract_tests.rs
+++ b/contracts/dca/src/tests/contract_tests.rs
@@ -34,6 +34,7 @@ fn instantiation_with_valid_admin_address_should_succeed() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
 
     let result = instantiate(deps.as_mut(), env, info, instantiate_message).unwrap();
@@ -64,6 +65,7 @@ fn instantiation_with_invalid_admin_address_should_fail() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
 
     let result = instantiate(deps.as_mut(), env, info, instantiate_message).unwrap_err();
@@ -91,6 +93,7 @@ fn instantiation_with_invalid_fee_collector_address_should_fail() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
 
     let result = instantiate(deps.as_mut(), env, info, instantiate_message).unwrap_err();
@@ -115,6 +118,7 @@ fn instantiation_with_fee_collector_amounts_not_equal_to_100_percent_should_fail
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
 
     let result = instantiate(deps.as_mut(), env, info, instantiate_message).unwrap_err();
@@ -142,6 +146,7 @@ fn create_pair_with_valid_address_should_succeed() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
     let _instantiate_result = instantiate(
         deps.as_mut(),
@@ -187,7 +192,9 @@ fn create_pair_that_already_exists_should_fail() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
+
     let _instantiate_result = instantiate(
         deps.as_mut(),
         env.clone(),
@@ -247,6 +254,7 @@ fn create_pair_with_invalid_address_should_fail() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
     let _instantiate_result = instantiate(
         deps.as_mut(),
@@ -287,6 +295,7 @@ fn create_pair_with_unauthorised_sender_should_fail() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
     let _instantiate_result = instantiate(
         deps.as_mut(),
@@ -331,6 +340,7 @@ fn delete_pair_with_valid_address_should_succeed() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
     let _instantiate_result = instantiate(
         deps.as_mut(),
@@ -386,6 +396,7 @@ fn get_all_pairs_with_one_whitelisted_pair_should_succeed() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
     let _instantiate_result = instantiate(
         deps.as_mut(),
@@ -437,6 +448,7 @@ fn get_all_pairs_with_no_whitelisted_pairs_should_succeed() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
     let _instantiate_result = instantiate(
         deps.as_mut(),
@@ -469,6 +481,7 @@ fn cancel_vault_with_valid_inputs_should_succeed() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
 
     let _instantiate_result = instantiate(
@@ -554,6 +567,7 @@ fn get_active_vault_by_address_and_id_should_succeed() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
 
     let _instantiate_result = instantiate(
@@ -634,6 +648,7 @@ fn get_all_active_vaults_by_address_should_succeed() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
 
     let _instantiate_result = instantiate(
@@ -747,6 +762,7 @@ fn get_all_events_by_vault_id_for_new_vault_should_succeed() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
 
     let _instantiate_result = instantiate(
@@ -832,6 +848,7 @@ fn get_all_events_by_vault_id_for_non_existent_vault_should_should_succeed() {
         staking_router_address: Addr::unchecked(VALID_ADDRESS_ONE),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
 
     let _instantiate_result = instantiate(

--- a/contracts/dca/src/tests/create_vault_tests.rs
+++ b/contracts/dca/src/tests/create_vault_tests.rs
@@ -1801,6 +1801,7 @@ fn when_contract_is_paused_should_fail() {
                 staking_router_address: None,
                 page_limit: None,
                 paused: Some(true),
+                dca_plus_escrow_level: None,
             },
             &[],
         )

--- a/contracts/dca/src/tests/deposit_tests.rs
+++ b/contracts/dca/src/tests/deposit_tests.rs
@@ -526,6 +526,7 @@ fn when_contract_is_paused_should_fail() {
                 staking_router_address: None,
                 page_limit: None,
                 paused: Some(true),
+                dca_plus_escrow_level: None,
             },
             &[],
         )

--- a/contracts/dca/src/tests/execute_trigger_tests.rs
+++ b/contracts/dca/src/tests/execute_trigger_tests.rs
@@ -2112,6 +2112,7 @@ fn when_contract_is_paused_should_fail() {
                 staking_router_address: None,
                 page_limit: None,
                 paused: Some(true),
+                dca_plus_escrow_level: None,
             },
             &[],
         )

--- a/contracts/dca/src/tests/get_config_tests.rs
+++ b/contracts/dca/src/tests/get_config_tests.rs
@@ -30,6 +30,7 @@ fn get_config_should_succeed() {
         staking_router_address: Addr::unchecked("staking-router"),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
     };
 
     let _instantiate_result = instantiate(

--- a/contracts/dca/src/tests/helpers.rs
+++ b/contracts/dca/src/tests/helpers.rs
@@ -34,6 +34,7 @@ pub fn instantiate_contract(deps: DepsMut, env: Env, info: MessageInfo) {
         staking_router_address: Addr::unchecked(ADMIN),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.0075").unwrap(),
     };
 
     instantiate(deps, env.clone(), info.clone(), instantiate_message).unwrap();
@@ -55,6 +56,7 @@ pub fn instantiate_contract_with_community_pool_fee_collector(
         staking_router_address: Addr::unchecked(ADMIN),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.0075").unwrap(),
     };
 
     instantiate(deps, env.clone(), info.clone(), instantiate_message).unwrap();
@@ -74,6 +76,7 @@ pub fn instantiate_contract_with_multiple_fee_collectors(
         staking_router_address: Addr::unchecked(ADMIN),
         page_limit: 1000,
         paused: false,
+        dca_plus_escrow_level: Decimal::from_str("0.0075").unwrap(),
     };
 
     instantiate(deps, env.clone(), info.clone(), instantiate_message).unwrap();

--- a/contracts/dca/src/tests/mocks.rs
+++ b/contracts/dca/src/tests/mocks.rs
@@ -81,6 +81,7 @@ impl MockApp {
                 staking_router_address: Addr::unchecked("staking-router"),
                 page_limit: 1000,
                 paused: false,
+                dca_plus_escrow_level: Decimal::from_str("0.05").unwrap(),
             },
             "dca",
         );

--- a/contracts/dca/src/validation_helpers.rs
+++ b/contracts/dca/src/validation_helpers.rs
@@ -240,6 +240,17 @@ pub fn assert_fee_collector_allocations_add_up_to_one(
     Ok(())
 }
 
+pub fn assert_dca_plus_escrow_level_is_less_than_100_percent(
+    dca_plus_escrow_level: Decimal,
+) -> Result<(), ContractError> {
+    if dca_plus_escrow_level > Decimal::percent(100) {
+        return Err(ContractError::CustomError {
+            val: "dca_plus_escrow_level cannot be greater than 100%".to_string(),
+        });
+    }
+    Ok(())
+}
+
 pub fn assert_no_destination_allocations_are_zero(
     destinations: &[Destination],
 ) -> Result<(), ContractError> {


### PR DESCRIPTION
@fluffydonkey adding escrow % level to the config so we can change it.

At this stage I'm thinking we will have a `DCAPlusConfig` object per dca plus vault that stores the escrow level at the time the vault was created and the dca plus model to be used when adjusting buy amounts.