### PR TITLE
Feat/dca out adjustments

### DIFF
--- a/contracts/dca/src/contract.rs
+++ b/contracts/dca/src/contract.rs
@@ -142,7 +142,7 @@ pub fn execute(
             time_interval,
             target_start_time_utc_seconds,
             target_receive_amount,
-            adjust_swap_amount,
+            dca_plus_direction,
         } => create_vault(
             deps,
             env,
@@ -158,7 +158,7 @@ pub fn execute(
             time_interval,
             target_start_time_utc_seconds,
             target_receive_amount,
-            adjust_swap_amount,
+            dca_plus_direction,
         ),
         ExecuteMsg::CancelVault { vault_id } => cancel_vault(deps, env, info, vault_id),
         ExecuteMsg::ExecuteTrigger { trigger_id } => execute_trigger_handler(deps, env, trigger_id),
@@ -192,9 +192,10 @@ pub fn execute(
             swap_fee_percent,
         } => create_custom_swap_fee(deps, info, denom, swap_fee_percent),
         ExecuteMsg::RemoveCustomSwapFee { denom } => remove_custom_swap_fee(deps, info, denom),
-        ExecuteMsg::UpdateSwapAdjustments { adjustments } => {
-            update_swap_adjustments_handler(deps, adjustments)
-        }
+        ExecuteMsg::UpdateSwapAdjustments {
+            direction,
+            adjustments,
+        } => update_swap_adjustments_handler(deps, direction, adjustments),
     }
 }
 

--- a/contracts/dca/src/handlers/after_fin_swap.rs
+++ b/contracts/dca/src/handlers/after_fin_swap.rs
@@ -146,7 +146,11 @@ pub fn after_fin_swap(deps: DepsMut, env: Env, reply: Reply) -> Result<Response,
                 dca_plus_config.escrowed_balance += amount_to_escrow;
 
                 let fee_percentage = Decimal::from_ratio(total_fee, coin_received.amount);
-                let swap_adjustment = get_swap_adjustment(deps.storage, dca_plus_config.model_id)?;
+                let swap_adjustment = get_swap_adjustment(
+                    deps.storage,
+                    dca_plus_config.direction,
+                    dca_plus_config.model_id,
+                )?;
                 let unadjusted_received_amount = coin_received.amount * swap_adjustment;
                 let unadjusted_received_amount_after_fee =
                     unadjusted_received_amount * (Decimal::one() - fee_percentage);

--- a/contracts/dca/src/handlers/create_vault.rs
+++ b/contracts/dca/src/handlers/create_vault.rs
@@ -8,7 +8,7 @@ use crate::state::events::create_event;
 use crate::state::pairs::PAIRS;
 use crate::state::triggers::save_trigger;
 use crate::state::vaults::{save_vault, update_vault};
-use crate::types::dca_plus_config::DCAPlusConfig;
+use crate::types::dca_plus_config::{DCAPlusConfig, DCAPlusDirection};
 use crate::types::vault::Vault;
 use crate::types::vault_builder::VaultBuilder;
 use crate::validation_helpers::{
@@ -46,7 +46,7 @@ pub fn create_vault(
     time_interval: TimeInterval,
     target_start_time_utc_seconds: Option<Uint64>,
     target_receive_amount: Option<Uint128>,
-    use_dca_plus: Option<bool>,
+    dca_plus_direction: Option<DCAPlusDirection>,
 ) -> Result<Response, ContractError> {
     assert_contract_is_not_paused(deps.storage)?;
     assert_address_is_valid(deps.as_ref(), owner.clone(), "owner".to_string())?;
@@ -91,11 +91,9 @@ pub fn create_vault(
 
     let config = get_config(deps.storage)?;
 
-    let dca_plus_config = use_dca_plus.map_or(None, |adjust_swap_amount| {
-        if !adjust_swap_amount {
-            return None;
-        };
+    let dca_plus_config = dca_plus_direction.map_or(None, |direction| {
         Some(DCAPlusConfig {
+            direction,
             escrow_level: config.dca_plus_escrow_level,
             model_id: get_dca_plus_model_id(
                 &env.block.time,

--- a/contracts/dca/src/handlers/update_swap_adjustments_handler.rs
+++ b/contracts/dca/src/handlers/update_swap_adjustments_handler.rs
@@ -1,10 +1,14 @@
-use crate::{error::ContractError, state::swap_adjustments::update_swap_adjustments};
+use crate::{
+    error::ContractError, state::swap_adjustments::update_swap_adjustments,
+    types::dca_plus_config::DCAPlusDirection,
+};
 use cosmwasm_std::{Decimal, DepsMut, Response};
 
 pub fn update_swap_adjustments_handler(
     deps: DepsMut,
+    direction: DCAPlusDirection,
     adjustments: Vec<(u8, Decimal)>,
 ) -> Result<Response, ContractError> {
-    update_swap_adjustments(deps.storage, adjustments)?;
+    update_swap_adjustments(deps.storage, direction, adjustments)?;
     Ok(Response::new())
 }

--- a/contracts/dca/src/helpers/vault_helpers.rs
+++ b/contracts/dca/src/helpers/vault_helpers.rs
@@ -12,10 +12,14 @@ pub fn get_swap_amount(deps: &Deps, vault: Vault) -> StdResult<Coin> {
         .clone()
         .dca_plus_config
         .map_or(initial_amount, |dca_plus_config| {
-            get_swap_adjustment(deps.storage, dca_plus_config.model_id)
-                .map_or(initial_amount, |adjustment_coefficient| {
-                    adjustment_coefficient * initial_amount
-                })
+            get_swap_adjustment(
+                deps.storage,
+                dca_plus_config.direction,
+                dca_plus_config.model_id,
+            )
+            .map_or(initial_amount, |adjustment_coefficient| {
+                adjustment_coefficient * initial_amount
+            })
         });
 
     Ok(Coin {

--- a/contracts/dca/src/msg.rs
+++ b/contracts/dca/src/msg.rs
@@ -8,6 +8,7 @@ use fin_helpers::position_type::PositionType;
 
 use crate::state::config::{Config, FeeCollector};
 use crate::state::data_fixes::DataFix;
+use crate::types::dca_plus_config::DCAPlusDirection;
 use crate::types::vault::Vault;
 
 #[cw_serde]
@@ -56,7 +57,7 @@ pub enum ExecuteMsg {
         time_interval: TimeInterval,
         target_start_time_utc_seconds: Option<Uint64>,
         target_receive_amount: Option<Uint128>,
-        adjust_swap_amount: Option<bool>,
+        dca_plus_direction: Option<DCAPlusDirection>,
     },
     Deposit {
         address: Addr,
@@ -90,6 +91,7 @@ pub enum ExecuteMsg {
         denom: String,
     },
     UpdateSwapAdjustments {
+        direction: DCAPlusDirection,
         adjustments: Vec<(u8, Decimal)>,
     },
 }

--- a/contracts/dca/src/state/swap_adjustments.rs
+++ b/contracts/dca/src/state/swap_adjustments.rs
@@ -1,18 +1,33 @@
 use cosmwasm_std::{Decimal, StdResult, Storage};
 use cw_storage_plus::Map;
 
-const SWAP_ADJUSTMENTS: Map<u8, Decimal> = Map::new("swap_adjustments_v20");
+use crate::types::dca_plus_config::DCAPlusDirection;
+
+const BUY_ADJUSTMENTS: Map<u8, Decimal> = Map::new("buy_adjustments_v20");
+const SELL_ADJUSTMENTS: Map<u8, Decimal> = Map::new("sell_adjustments_v20");
+
+pub fn adjustments_store(direction: DCAPlusDirection) -> &'static Map<'static, u8, Decimal> {
+    match direction {
+        DCAPlusDirection::In => &BUY_ADJUSTMENTS,
+        DCAPlusDirection::Out => &SELL_ADJUSTMENTS,
+    }
+}
 
 pub fn update_swap_adjustments(
     storage: &mut dyn Storage,
+    direction: DCAPlusDirection,
     adjustments: Vec<(u8, Decimal)>,
 ) -> StdResult<()> {
     for (model, adjustment) in adjustments {
-        SWAP_ADJUSTMENTS.save(storage, model, &adjustment)?;
+        adjustments_store(direction.clone()).save(storage, model, &adjustment)?;
     }
     Ok(())
 }
 
-pub fn get_swap_adjustment(storage: &dyn Storage, model: u8) -> StdResult<Decimal> {
-    SWAP_ADJUSTMENTS.load(storage, model)
+pub fn get_swap_adjustment(
+    storage: &dyn Storage,
+    direction: DCAPlusDirection,
+    model: u8,
+) -> StdResult<Decimal> {
+    adjustments_store(direction).load(storage, model)
 }

--- a/contracts/dca/src/tests/after_fin_swap_tests.rs
+++ b/contracts/dca/src/tests/after_fin_swap_tests.rs
@@ -1,17 +1,3 @@
-use base::{
-    events::event::{EventBuilder, EventData, ExecutionSkippedReason},
-    helpers::{community_pool::create_fund_community_pool_msg, math_helpers::checked_mul},
-    triggers::trigger::{Trigger, TriggerConfiguration},
-    vaults::vault::{PostExecutionAction, VaultStatus},
-};
-use cosmwasm_std::{
-    testing::{mock_dependencies, mock_env, mock_info},
-    BankMsg, Coin, Decimal, Decimal256, Reply, SubMsg, SubMsgResponse, SubMsgResult, Timestamp,
-    Uint128,
-};
-use fin_helpers::codes::ERROR_SWAP_SLIPPAGE_EXCEEDED;
-use std::{cmp::min, str::FromStr};
-
 use crate::{
     constants::TEN,
     contract::{AFTER_BANK_SWAP_REPLY_ID, AFTER_FIN_SWAP_REPLY_ID},
@@ -34,7 +20,21 @@ use crate::{
         },
         mocks::{ADMIN, DENOM_UKUJI},
     },
+    types::dca_plus_config::DCAPlusDirection,
 };
+use base::{
+    events::event::{EventBuilder, EventData, ExecutionSkippedReason},
+    helpers::{community_pool::create_fund_community_pool_msg, math_helpers::checked_mul},
+    triggers::trigger::{Trigger, TriggerConfiguration},
+    vaults::vault::{PostExecutionAction, VaultStatus},
+};
+use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env, mock_info},
+    BankMsg, Coin, Decimal, Decimal256, Reply, SubMsg, SubMsgResponse, SubMsgResult, Timestamp,
+    Uint128,
+};
+use fin_helpers::codes::ERROR_SWAP_SLIPPAGE_EXCEEDED;
+use std::{cmp::min, str::FromStr};
 
 #[test]
 fn with_succcesful_swap_returns_funds_to_destination() {
@@ -608,6 +608,7 @@ fn with_succcesful_swap_with_dca_plus_escrows_funds() {
 
     update_swap_adjustments(
         deps.as_mut().storage,
+        DCAPlusDirection::In,
         vec![
             (30, Decimal::from_str("1.0").unwrap()),
             (35, Decimal::from_str("1.0").unwrap()),
@@ -714,6 +715,7 @@ fn with_succcesful_swap_with_dca_plus_updates_standard_dca_received_amount() {
 
     update_swap_adjustments(
         deps.as_mut().storage,
+        DCAPlusDirection::In,
         vec![
             (30, Decimal::from_str("1.3").unwrap()),
             (35, Decimal::from_str("1.3").unwrap()),

--- a/contracts/dca/src/tests/contract_tests.rs
+++ b/contracts/dca/src/tests/contract_tests.rs
@@ -517,7 +517,7 @@ fn cancel_vault_with_valid_inputs_should_succeed() {
         target_start_time_utc_seconds: Some(Uint64::new(1762770365)),
         target_receive_amount: None,
         minimum_receive_amount: None,
-        adjust_swap_amount: None,
+        dca_plus_direction: None,
     };
 
     let coin = Coin {
@@ -604,7 +604,7 @@ fn get_active_vault_by_address_and_id_should_succeed() {
         target_start_time_utc_seconds: Some(Uint64::new(1662770365)),
         target_receive_amount: None,
         minimum_receive_amount: None,
-        adjust_swap_amount: None,
+        dca_plus_direction: None,
     };
 
     let coin = Coin {
@@ -686,7 +686,7 @@ fn get_all_active_vaults_by_address_should_succeed() {
         target_start_time_utc_seconds: Some(Uint64::new(1662770365)),
         target_receive_amount: None,
         minimum_receive_amount: None,
-        adjust_swap_amount: None,
+        dca_plus_direction: None,
     };
 
     let coin_one = Coin {
@@ -715,7 +715,7 @@ fn get_all_active_vaults_by_address_should_succeed() {
         target_start_time_utc_seconds: Some(Uint64::new(1662770365)),
         target_receive_amount: None,
         minimum_receive_amount: None,
-        adjust_swap_amount: None,
+        dca_plus_direction: None,
     };
 
     let coin_two = Coin {
@@ -802,7 +802,7 @@ fn get_all_events_by_vault_id_for_new_vault_should_succeed() {
         target_start_time_utc_seconds: Some(Uint64::new(1762770365)),
         target_receive_amount: None,
         minimum_receive_amount: None,
-        adjust_swap_amount: None,
+        dca_plus_direction: None,
     };
 
     let coin = Coin {

--- a/contracts/dca/src/tests/create_vault_tests.rs
+++ b/contracts/dca/src/tests/create_vault_tests.rs
@@ -7,7 +7,7 @@ use crate::tests::helpers::{
 use crate::tests::mocks::{
     fin_contract_unfilled_limit_order, MockApp, ADMIN, DENOM_UKUJI, DENOM_UTEST, USER,
 };
-use crate::types::dca_plus_config::DCAPlusConfig;
+use crate::types::dca_plus_config::{DCAPlusConfig, DCAPlusDirection};
 use crate::types::vault::Vault;
 use base::events::event::{EventBuilder, EventData};
 use base::helpers::math_helpers::checked_mul;
@@ -61,7 +61,7 @@ fn with_price_trigger_should_update_address_balances() {
                 time_interval: TimeInterval::Hourly,
                 target_receive_amount: Some(swap_amount),
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI.to_string())],
         )
@@ -129,7 +129,7 @@ fn with_price_trigger_should_create_vault() {
                 time_interval: TimeInterval::Hourly,
                 target_receive_amount: Some(swap_amount),
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UKUJI))],
         )
@@ -184,7 +184,7 @@ fn with_price_trigger_for_fin_buy_should_create_correct_trigger() {
                 time_interval: TimeInterval::Hourly,
                 target_receive_amount: Some(swap_amount * Uint128::new(10)),
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UKUJI))],
         )
@@ -242,7 +242,7 @@ fn with_price_trigger_for_fin_sell_should_create_correct_trigger() {
                 time_interval: TimeInterval::Hourly,
                 target_receive_amount: Some(swap_amount * Uint128::new(10)),
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UTEST))],
         )
@@ -298,7 +298,7 @@ fn with_price_trigger_should_publish_vault_created_event() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: Some(swap_amount),
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -345,7 +345,7 @@ fn with_price_trigger_should_publish_funds_deposited_event() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: Some(swap_amount),
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -400,7 +400,7 @@ fn with_price_trigger_with_existing_vault_should_create_vault() {
                 time_interval: TimeInterval::Hourly,
                 target_receive_amount: Some(swap_amount),
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -479,7 +479,7 @@ fn with_price_trigger_twice_for_user_should_succeed() {
                 time_interval: TimeInterval::Hourly,
                 target_receive_amount: Some(swap_amount),
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI.to_string())],
         )
@@ -574,7 +574,7 @@ fn with_immediate_time_trigger_should_update_address_balances() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -635,7 +635,7 @@ fn with_immediate_time_trigger_should_update_vault_balance() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -678,7 +678,7 @@ fn with_immediate_time_trigger_should_create_active_vault() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -765,7 +765,7 @@ fn with_immediate_time_trigger_should_publish_events() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -858,7 +858,7 @@ fn with_immediate_time_trigger_and_slippage_failure_should_update_address_balanc
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -909,7 +909,7 @@ fn with_immediate_time_trigger_and_slippage_failure_should_update_vault_balance(
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -954,7 +954,7 @@ fn with_time_trigger_should_create_vault() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: Some(Uint64::from(target_start_time.seconds())),
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1044,7 +1044,7 @@ fn with_time_trigger_should_update_address_balances() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: Some(Uint64::from(target_start_time.seconds())),
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1095,7 +1095,7 @@ fn with_time_trigger_should_publish_vault_created_event() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1143,7 +1143,7 @@ fn with_time_trigger_should_publish_funds_deposited_event() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1202,7 +1202,7 @@ fn with_time_trigger_with_existing_vault_should_create_vault() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: Some(Uint64::from(target_start_time.seconds())),
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1284,7 +1284,7 @@ fn with_time_trigger_with_target_time_in_the_past_should_fail() {
                     mock.app.block_info().time.seconds() - 60,
                 )),
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1336,7 +1336,7 @@ fn with_multiple_destinations_should_succeed() {
                     (mock.app.block_info().time.seconds() + 10).into(),
                 ),
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1416,7 +1416,7 @@ fn with_price_and_time_trigger_should_fail() {
                     mock.app.block_info().time.plus_seconds(2).seconds(),
                 )),
                 target_receive_amount: Some(swap_amount),
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1456,7 +1456,7 @@ fn with_no_assets_should_fail() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![],
         )
@@ -1495,7 +1495,7 @@ fn with_multiple_assets_should_fail() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![
                 Coin::new(vault_deposit.into(), DENOM_UTEST),
@@ -1539,7 +1539,7 @@ fn with_non_existent_pair_address_should_fail() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1584,7 +1584,7 @@ fn with_destination_allocations_less_than_100_percent_should_fail() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1636,7 +1636,7 @@ fn with_destination_allocation_equal_to_zero_should_fail() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1687,7 +1687,7 @@ fn with_more_than_10_destination_allocations_should_fail() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1729,7 +1729,7 @@ fn with_passed_in_owner_should_succeed() {
                 time_interval: TimeInterval::Hourly,
                 target_receive_amount: Some(swap_amount),
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UKUJI))],
         )
@@ -1787,7 +1787,7 @@ fn with_swap_amount_less_than_50000_should_fail() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: None,
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1860,7 +1860,7 @@ fn when_contract_is_paused_should_fail() {
                 time_interval: TimeInterval::Hourly,
                 target_receive_amount: None,
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UKUJI))],
         )
@@ -1902,7 +1902,7 @@ fn with_insufficient_funds_should_create_inactive_vault() {
                 time_interval: TimeInterval::Hourly,
                 target_start_time_utc_seconds: Some(Uint64::from(target_start_time.seconds())),
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )
@@ -1989,7 +1989,7 @@ fn with_adjust_swap_amount_true_should_create_dca_plus_config() {
                 time_interval: TimeInterval::Hourly,
                 target_receive_amount: Some(swap_amount),
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: Some(true),
+                dca_plus_direction: Some(DCAPlusDirection::In),
             },
             &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UKUJI))],
         )
@@ -2009,6 +2009,7 @@ fn with_adjust_swap_amount_true_should_create_dca_plus_config() {
     assert_eq!(
         vault_response.vault.dca_plus_config,
         Some(DCAPlusConfig {
+            direction: DCAPlusDirection::In,
             escrow_level: Decimal::percent(5),
             model_id: 30,
             escrowed_balance: Uint128::zero(),
@@ -2058,7 +2059,7 @@ fn with_long_execution_duration_should_select_longer_duration_model() {
                 time_interval: TimeInterval::Daily,
                 target_receive_amount: Some(swap_amount),
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: Some(true),
+                dca_plus_direction: Some(DCAPlusDirection::In),
             },
             &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UKUJI))],
         )
@@ -2078,6 +2079,7 @@ fn with_long_execution_duration_should_select_longer_duration_model() {
     assert_eq!(
         vault_response.vault.dca_plus_config,
         Some(DCAPlusConfig {
+            direction: DCAPlusDirection::In,
             escrow_level: Decimal::percent(5),
             model_id: 80,
             escrowed_balance: Uint128::zero(),
@@ -2127,7 +2129,7 @@ fn with_small_deposit_should_select_shorter_duration_model() {
                 time_interval: TimeInterval::Daily,
                 target_receive_amount: Some(swap_amount),
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: Some(true),
+                dca_plus_direction: Some(DCAPlusDirection::In),
             },
             &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UKUJI))],
         )
@@ -2147,6 +2149,7 @@ fn with_small_deposit_should_select_shorter_duration_model() {
     assert_eq!(
         vault_response.vault.dca_plus_config,
         Some(DCAPlusConfig {
+            direction: DCAPlusDirection::In,
             escrow_level: Decimal::percent(5),
             model_id: 30,
             escrowed_balance: Uint128::zero(),

--- a/contracts/dca/src/tests/execute_trigger_tests.rs
+++ b/contracts/dca/src/tests/execute_trigger_tests.rs
@@ -12,6 +12,7 @@ use crate::tests::mocks::{
     fin_contract_low_swap_price, fin_contract_pass_slippage_tolerance,
     fin_contract_unfilled_limit_order, MockApp, ADMIN, DENOM_UKUJI, DENOM_UTEST, USER,
 };
+use crate::types::dca_plus_config::DCAPlusDirection;
 use base::events::event::{EventBuilder, EventData};
 use base::helpers::math_helpers::checked_mul;
 use base::vaults::vault::{Destination, PostExecutionAction, VaultStatus};
@@ -1175,7 +1176,7 @@ fn for_ready_time_trigger_with_dca_plus_should_withhold_escrow() {
             swap_amount,
             "time",
             None,
-            Some(true),
+            Some(DCAPlusDirection::In),
         );
 
     mock.app
@@ -1183,6 +1184,7 @@ fn for_ready_time_trigger_with_dca_plus_should_withhold_escrow() {
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::UpdateSwapAdjustments {
+                direction: DCAPlusDirection::In,
                 adjustments: vec![
                     (30, Decimal::from_str("1.0").unwrap()),
                     (35, Decimal::from_str("1.0").unwrap()),
@@ -1284,7 +1286,7 @@ fn for_ready_time_trigger_with_dca_plus_should_adjust_swap_amount() {
             swap_amount,
             "time",
             None,
-            Some(true),
+            Some(DCAPlusDirection::In),
         );
 
     mock.app
@@ -1292,6 +1294,7 @@ fn for_ready_time_trigger_with_dca_plus_should_adjust_swap_amount() {
             Addr::unchecked(ADMIN),
             mock.dca_contract_address.clone(),
             &ExecuteMsg::UpdateSwapAdjustments {
+                direction: DCAPlusDirection::In,
                 adjustments: vec![
                     (30, Decimal::from_str("1.3").unwrap()),
                     (35, Decimal::from_str("1.3").unwrap()),

--- a/contracts/dca/src/tests/get_time_trigger_ids_tests.rs
+++ b/contracts/dca/src/tests/get_time_trigger_ids_tests.rs
@@ -37,7 +37,7 @@ fn should_return_active_triggers_only() {
                     mock.app.block_info().time.seconds() + 100,
                 )),
                 target_receive_amount: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), DENOM_UKUJI)],
         )

--- a/contracts/dca/src/tests/get_trigger_id_by_fin_limit_order_idx_tests.rs
+++ b/contracts/dca/src/tests/get_trigger_id_by_fin_limit_order_idx_tests.rs
@@ -39,7 +39,7 @@ fn should_fetch_existing_trigger_id_by_order_idx() {
                 time_interval: TimeInterval::Hourly,
                 target_receive_amount: Some(swap_amount),
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UKUJI))],
         )

--- a/contracts/dca/src/tests/helpers.rs
+++ b/contracts/dca/src/tests/helpers.rs
@@ -12,7 +12,11 @@ use crate::{
         triggers::save_trigger,
         vaults::save_vault,
     },
-    types::{dca_plus_config::DCAPlusConfig, vault::Vault, vault_builder::VaultBuilder},
+    types::{
+        dca_plus_config::{DCAPlusConfig, DCAPlusDirection},
+        vault::Vault,
+        vault_builder::VaultBuilder,
+    },
 };
 use base::{
     events::event::Event,
@@ -123,6 +127,7 @@ pub fn setup_vault(
             started_at: None,
             dca_plus_config: if is_dca_plus {
                 Some(DCAPlusConfig {
+                    direction: DCAPlusDirection::In,
                     escrow_level: Decimal::percent(5),
                     model_id: 30,
                     escrowed_balance: Uint128::zero(),

--- a/contracts/dca/src/tests/mocks.rs
+++ b/contracts/dca/src/tests/mocks.rs
@@ -2,6 +2,7 @@ use crate::constants::{ONE_THOUSAND, TWO_MICRONS};
 use crate::contract::reply;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, VaultResponse};
 use crate::state::config::FeeCollector;
+use crate::types::dca_plus_config::DCAPlusDirection;
 use crate::types::vault::Vault;
 use base::helpers::message_helpers::get_flat_map_for_event_type;
 use base::triggers::trigger::TimeInterval;
@@ -215,7 +216,7 @@ impl MockApp {
                     time_interval: TimeInterval::Hourly,
                     target_receive_amount: Some(swap_amount),
                     target_start_time_utc_seconds: None,
-                    adjust_swap_amount: None,
+                    dca_plus_direction: None,
                 },
                 &vec![balance],
             )
@@ -257,7 +258,7 @@ impl MockApp {
                     time_interval: TimeInterval::Hourly,
                     target_receive_amount: Some(swap_amount),
                     target_start_time_utc_seconds: None,
-                    adjust_swap_amount: None,
+                    dca_plus_direction: None,
                 },
                 &vec![balance],
             )
@@ -316,7 +317,7 @@ impl MockApp {
                     time_interval: TimeInterval::Hourly,
                     target_receive_amount: Some(swap_amount),
                     target_start_time_utc_seconds: None,
-                    adjust_swap_amount: None,
+                    dca_plus_direction: None,
                 },
                 &vec![balance],
             )
@@ -363,7 +364,7 @@ impl MockApp {
         swap_amount: Uint128,
         label: &str,
         minimum_receive_amount: Option<Uint128>,
-        is_dca_plus: Option<bool>,
+        dca_plus_direction: Option<DCAPlusDirection>,
     ) -> MockApp {
         let response = self
             .app
@@ -384,7 +385,7 @@ impl MockApp {
                         self.app.block_info().time.plus_seconds(2).seconds(),
                     )),
                     target_receive_amount: None,
-                    adjust_swap_amount: is_dca_plus,
+                    dca_plus_direction,
                 },
                 &vec![balance],
             )
@@ -427,7 +428,7 @@ impl MockApp {
                     time_interval: TimeInterval::Hourly,
                     target_start_time_utc_seconds: None,
                     target_receive_amount: None,
-                    adjust_swap_amount: None,
+                    dca_plus_direction: None,
                 },
                 &vec![balance],
             )
@@ -467,7 +468,7 @@ impl MockApp {
                     time_interval: TimeInterval::Hourly,
                     target_start_time_utc_seconds: None,
                     target_receive_amount: None,
-                    adjust_swap_amount: None,
+                    dca_plus_direction: None,
                 },
                 &vec![Coin::new(1, DENOM_UKUJI)],
             )

--- a/contracts/dca/src/tests/update_swap_adjustments_tests.rs
+++ b/contracts/dca/src/tests/update_swap_adjustments_tests.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use crate::{
     handlers::update_swap_adjustments_handler::update_swap_adjustments_handler,
-    state::swap_adjustments::get_swap_adjustment,
+    state::swap_adjustments::get_swap_adjustment, types::dca_plus_config::DCAPlusDirection,
 };
 
 #[test]
@@ -22,7 +22,8 @@ fn updates_swap_adjustments() {
     ];
 
     let mut deps = mock_dependencies();
-    update_swap_adjustments_handler(deps.as_mut(), old_adjustments.clone()).unwrap();
+    update_swap_adjustments_handler(deps.as_mut(), DCAPlusDirection::In, old_adjustments.clone())
+        .unwrap();
 
     let new_adjustments = vec![
         (30, Decimal::from_str("1.921").unwrap()),
@@ -37,11 +38,13 @@ fn updates_swap_adjustments() {
         (90, Decimal::from_str("1.981").unwrap()),
     ];
 
-    update_swap_adjustments_handler(deps.as_mut(), new_adjustments.clone()).unwrap();
+    update_swap_adjustments_handler(deps.as_mut(), DCAPlusDirection::In, new_adjustments.clone())
+        .unwrap();
 
     new_adjustments.iter().zip(old_adjustments.iter()).for_each(
         |((model, new_adjustment), (_, old_adjustment))| {
-            let stored_adjustment = get_swap_adjustment(deps.as_ref().storage, *model).unwrap();
+            let stored_adjustment =
+                get_swap_adjustment(deps.as_ref().storage, DCAPlusDirection::In, *model).unwrap();
             assert_eq!(stored_adjustment, *new_adjustment);
             assert_ne!(stored_adjustment, *old_adjustment);
         },

--- a/contracts/dca/src/tests/update_vault_tests.rs
+++ b/contracts/dca/src/tests/update_vault_tests.rs
@@ -41,7 +41,7 @@ fn should_succeed() {
                 time_interval: TimeInterval::Daily,
                 target_receive_amount: None,
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UKUJI))],
         )
@@ -103,7 +103,7 @@ fn cancelled_vault_should_fail() {
                 time_interval: TimeInterval::Daily,
                 target_receive_amount: None,
                 target_start_time_utc_seconds: None,
-                adjust_swap_amount: None,
+                dca_plus_direction: None,
             },
             &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UKUJI))],
         )

--- a/contracts/dca/src/types/dca_plus_config.rs
+++ b/contracts/dca/src/types/dca_plus_config.rs
@@ -3,8 +3,16 @@ use cosmwasm_std::{Decimal, Uint128};
 
 #[cw_serde]
 pub struct DCAPlusConfig {
+    pub direction: DCAPlusDirection,
     pub escrow_level: Decimal,
     pub model_id: u8,
     pub standard_dca_received_amount: Uint128,
     pub escrowed_balance: Uint128,
+}
+
+#[cw_serde]
+#[derive(Copy)]
+pub enum DCAPlusDirection {
+    In = 0,
+    Out = 1,
 }


### PR DESCRIPTION
Add DCA+ direction enum.

@fluffydonkey this allows us to store coefficients for both DCA in and out. The downside is that we need to add some knowledge of DCA in/out to the contract when creating a DCA+ vault, something we had managed to avoid introducing until now...