### PR TITLE
add get dca plus performance endpoint

### DIFF
--- a/contracts/dca/src/contract.rs
+++ b/contracts/dca/src/contract.rs
@@ -15,6 +15,7 @@ use crate::handlers::deposit::deposit;
 use crate::handlers::execute_trigger::execute_trigger_handler;
 use crate::handlers::get_custom_swap_fees::get_custom_swap_fees;
 use crate::handlers::get_data_fixes_by_resource_id::get_data_fixes_by_resource_id;
+use crate::handlers::get_dca_plus_performance::get_dca_plus_performance_handler;
 use crate::handlers::get_events::get_events;
 use crate::handlers::get_events_by_resource_id::get_events_by_resource_id;
 use crate::handlers::get_pairs::get_pairs;
@@ -282,5 +283,8 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::GetConfig {} => to_binary(&ConfigResponse {
             config: get_config(deps.storage)?,
         }),
+        QueryMsg::GetDCAPlusPerformance { vault_id } => {
+            to_binary(&get_dca_plus_performance_handler(deps, vault_id)?)
+        }
     }
 }

--- a/contracts/dca/src/handlers/claim_escrowed_funds.rs
+++ b/contracts/dca/src/handlers/claim_escrowed_funds.rs
@@ -3,7 +3,7 @@ use crate::{
     helpers::validation_helpers::assert_sender_is_admin_or_vault_owner,
     helpers::{
         disbursement_helpers::{get_disbursement_messages, get_fee_messages},
-        vault_helpers::get_dca_plus_fee,
+        vault_helpers::get_dca_plus_performance_fee,
     },
     state::vaults::{get_vault, update_vault},
 };
@@ -39,7 +39,7 @@ pub fn claim_escrowed_funds_handler(
         PriceType::Belief,
     )?;
 
-    let performance_fee = get_dca_plus_fee(&vault, current_price)?;
+    let performance_fee = get_dca_plus_performance_fee(&vault, current_price)?;
     let amount_to_disburse = dca_plus_config.escrowed_balance - performance_fee.amount;
 
     dca_plus_config.escrowed_balance = Uint128::zero();

--- a/contracts/dca/src/handlers/get_dca_plus_performance.rs
+++ b/contracts/dca/src/handlers/get_dca_plus_performance.rs
@@ -1,0 +1,34 @@
+use crate::{
+    helpers::vault_helpers::{get_dca_plus_performance_factor, get_dca_plus_performance_fee},
+    msg::DCAPlusPerformanceResponse,
+    state::vaults::get_vault,
+};
+use base::price_type::PriceType;
+use cosmwasm_std::{Coin, Deps, StdError, StdResult, Uint128};
+use fin_helpers::queries::query_price;
+
+pub fn get_dca_plus_performance_handler(
+    deps: Deps,
+    vault_id: Uint128,
+) -> StdResult<DCAPlusPerformanceResponse> {
+    let vault = get_vault(deps.storage, vault_id)?;
+
+    let current_price = query_price(
+        deps.querier,
+        vault.pair.clone(),
+        &Coin::new(0, vault.get_swap_denom()),
+        PriceType::Belief,
+    )?;
+
+    vault.dca_plus_config.clone().map_or(
+        Err(StdError::GenericErr {
+            msg: format!("Vault {} is not a DCA Plus vault", vault_id),
+        }),
+        |_| {
+            Ok(DCAPlusPerformanceResponse {
+                performance_fee: get_dca_plus_performance_fee(&vault, current_price)?,
+                performance_factor: get_dca_plus_performance_factor(&vault, current_price)?,
+            })
+        },
+    )
+}

--- a/contracts/dca/src/handlers/get_vault.rs
+++ b/contracts/dca/src/handlers/get_vault.rs
@@ -4,7 +4,5 @@ use cosmwasm_std::{Deps, StdResult, Uint128};
 pub fn get_vault(deps: Deps, vault_id: Uint128) -> StdResult<VaultResponse> {
     let vault = fetch_vault(deps.storage, vault_id.into())?;
 
-    Ok(VaultResponse {
-        vault: vault.clone(),
-    })
+    Ok(VaultResponse { vault })
 }

--- a/contracts/dca/src/handlers/mod.rs
+++ b/contracts/dca/src/handlers/mod.rs
@@ -14,6 +14,7 @@ pub mod deposit;
 pub mod execute_trigger;
 pub mod get_custom_swap_fees;
 pub mod get_data_fixes_by_resource_id;
+pub mod get_dca_plus_performance;
 pub mod get_events;
 pub mod get_events_by_resource_id;
 pub mod get_pairs;

--- a/contracts/dca/src/msg.rs
+++ b/contracts/dca/src/msg.rs
@@ -1,15 +1,13 @@
+use crate::state::config::{Config, FeeCollector};
+use crate::state::data_fixes::DataFix;
+use crate::types::vault::Vault;
 use base::events::event::Event;
 use base::pair::Pair;
 use base::triggers::trigger::TimeInterval;
 use base::vaults::vault::{Destination, VaultStatus};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Decimal, Decimal256, Uint128, Uint64};
+use cosmwasm_std::{Addr, Coin, Decimal, Decimal256, Uint128, Uint64};
 use fin_helpers::position_type::PositionType;
-
-use crate::state::config::{Config, FeeCollector};
-use crate::state::data_fixes::DataFix;
-
-use crate::types::vault::Vault;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -143,6 +141,8 @@ pub enum QueryMsg {
         start_after: Option<u64>,
         limit: Option<u16>,
     },
+    #[returns(DCAPlusPerformanceResponse)]
+    GetDCAPlusPerformance { vault_id: Uint128 },
 }
 
 #[cw_serde]
@@ -168,6 +168,12 @@ pub struct TriggerIdsResponse {
 #[cw_serde]
 pub struct VaultResponse {
     pub vault: Vault,
+}
+
+#[cw_serde]
+pub struct DCAPlusPerformanceResponse {
+    pub performance_fee: Coin,
+    pub performance_factor: Decimal,
 }
 
 #[cw_serde]


### PR DESCRIPTION
@fluffydonkey @dougcalc a new query endpoint with the DCAPlusPerformance response that includes:
- `performance_fee` - how much we would take out of the escrow as a fee if they cancelled their vault right now
- `performance_factor` - the performance of the vault compared to standard DCA+ as a factor (i.e. 1.2 == 20% improvement)

